### PR TITLE
Feature/select updates

### DIFF
--- a/lib/_theming.scss
+++ b/lib/_theming.scss
@@ -35,4 +35,9 @@
       display: block;
     }
   }
+
+  .mat-select-search-inside-mat-option .mat-select-search-clear {
+    right: 0 !important;
+    top: 0 !important;
+  }
 }

--- a/lib/src/lib/components/form-fields/select-field/field-select.model.ts
+++ b/lib/src/lib/components/form-fields/select-field/field-select.model.ts
@@ -29,7 +29,7 @@ export interface FormFieldSelectOptions extends FormFieldBaseOptions {
     notFoundLabel?: string;
     /**
      * Clear the search when the select closes
-     * @default true
+     * @default false
      */
     clearOnClose?: boolean;
   };

--- a/lib/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.html
@@ -6,8 +6,12 @@
   id="lab900-select-field-{{ schema?.attribute }}"
 >
   <mat-label>
-    <ng-container *ngIf="loading">{{ 'form.field.loading' | translate }}</ng-container>
-    <ng-container *ngIf="schema.title && !loading">{{ schema.title | translate }}</ng-container>
+    <ng-container *ngIf="loading">{{
+      'form.field.loading' | translate
+    }}</ng-container>
+    <ng-container *ngIf="schema.title && !loading">{{
+      schema.title | translate
+    }}</ng-container>
   </mat-label>
   <mat-select
     #select
@@ -27,26 +31,48 @@
         [searching]="loading"
         (ngModelChange)="onSearch($event)"
         [ngModelOptions]="{ standalone: true }"
-        [placeholderLabel]="options?.search?.placeholder || 'form.field.search' | translate"
-        [noEntriesFoundLabel]="options?.search?.notFoundLabel || 'form.field.no_options_found' | translate"
-        [disableScrollToActiveOnOptionsChanged]="options?.infiniteScroll?.enabled"
+        [placeholderLabel]="
+          options?.search?.placeholder || 'form.field.search' | translate
+        "
+        [noEntriesFoundLabel]="
+          options?.search?.notFoundLabel || 'form.field.no_options_found'
+            | translate
+        "
+        [disableScrollToActiveOnOptionsChanged]="
+          options?.infiniteScroll?.enabled
+        "
+        [clearSearchInput]="options?.search?.clearOnClose || false"
       ></ngx-mat-select-search>
     </mat-option>
     <mat-option *ngFor="let item of selectOptions" [value]="item.value">
-      <div *ngIf="options?.displayOptionFn" [innerHTML]="options.displayOptionFn(item) | translate"></div>
-      <ng-container *ngIf="!options?.displayOptionFn">{{ item.label | translate }}</ng-container>
+      <div
+        *ngIf="options?.displayOptionFn"
+        [innerHTML]="options.displayOptionFn(item) | translate"
+      ></div>
+      <ng-container *ngIf="!options?.displayOptionFn">{{
+        item.label | translate
+      }}</ng-container>
     </mat-option>
   </mat-select>
-  <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && select.value)"
+  <mat-hint
+    *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && select.value)"
     ><span [innerHTML]="hint | translate: hintValueTranslateData"></span
   ></mat-hint>
-  <mat-error *ngIf="!valid"><span [innerHTML]="getErrorMessage() | async"></span></mat-error>
+  <mat-error *ngIf="!valid"
+    ><span [innerHTML]="getErrorMessage() | async"></span
+  ></mat-error>
 </mat-form-field>
 
 <div class="lab900-readonly-field" *ngIf="fieldIsReadonly && !fieldIsHidden">
-  <span *ngIf="options?.readonlyLabel || schema.title" class="lab900-readonly-field__label">{{
-    options?.readonlyLabel || schema.title | translate
-  }}</span>
-  <div *ngIf="!loading || !fieldControl.value">{{ selectedOption?.label || '-' | translate }}</div>
-  <div *ngIf="loading && fieldControl.value">{{ 'form.field.loading' | translate }}</div>
+  <span
+    *ngIf="options?.readonlyLabel || schema.title"
+    class="lab900-readonly-field__label"
+    >{{ options?.readonlyLabel || schema.title | translate }}</span
+  >
+  <div *ngIf="!loading || !fieldControl.value">
+    {{ selectedOption?.label || '-' | translate }}
+  </div>
+  <div *ngIf="loading && fieldControl.value">
+    {{ 'form.field.loading' | translate }}
+  </div>
 </div>

--- a/src/app/modules/showcase-forms/examples/form-field-select-example/form-field-select-advanced-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-select-example/form-field-select-advanced-example.component.ts
@@ -9,11 +9,20 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+const tolkienBook: any = {
+  key: '/works/OL27500W',
+  title: 'The letters of J.R.R. Tolkien',
+};
+
+const compare = (a: any, b: any): boolean =>
+  a?.key && b?.key && a.key === b.key;
+
 @Component({
   selector: 'lab900-form-field-select-advanced-example',
-  template: '<lab900-form [schema]="formSchema"></lab900-form>',
+  template: '<lab900-form [schema]="formSchema" [data]="data"></lab900-form>',
 })
 export class FormFieldSelectAdvancedExampleComponent {
+  public data: any = { books2: tolkienBook };
   public formSchema: Lab900FormConfig = {
     fields: [
       {
@@ -25,8 +34,10 @@ export class FormFieldSelectAdvancedExampleComponent {
             title: 'Select a book',
             editType: EditType.Select,
             options: {
+              compareWith: compare,
+              displayOptionFn: (o) => o?.value?.title,
               selectOptions: this.getSelectOptions.bind(this),
-              colspan: 6,
+              colspan: 4,
               infiniteScroll: {
                 enabled: true,
               },
@@ -37,8 +48,28 @@ export class FormFieldSelectAdvancedExampleComponent {
             title: 'Search a book',
             editType: EditType.Select,
             options: {
+              compareWith: compare,
+              displayOptionFn: (o) => o?.value?.title,
               selectOptions: this.getSelectOptions.bind(this),
-              colspan: 6,
+              colspan: 4,
+              infiniteScroll: {
+                enabled: true,
+              },
+              search: {
+                enabled: true,
+              },
+            },
+          },
+          {
+            attribute: 'books3',
+            title: 'Search multiple book',
+            editType: EditType.Select,
+            options: {
+              compareWith: compare,
+              displayOptionFn: (o) => o?.value?.title,
+              selectOptions: this.getSelectOptions.bind(this),
+              colspan: 4,
+              multiple: true,
               infiniteScroll: {
                 enabled: true,
               },
@@ -71,6 +102,7 @@ export class FormFieldSelectAdvancedExampleComponent {
             editType: EditType.Select,
             options: {
               selectOptions: this.getSelectOptions.bind(this),
+              compareWith: compare,
               colspan: 6,
               infiniteScroll: {
                 enabled: true,


### PR DESCRIPTION
## Purpose
Fixed some missing things from #9  
1. don't clear the select search on select close (optional)
2. add form control value to the options if they don't exist otherwise some selects could appear empty while actually having a value. 

## Approach
### Clear search
Added the clearSearchInput option that the ngx-mat-search libs provides

### Add form control value to the options 
Whenever the select options are set again a check happens on the current form control value. If the value(s) are not in the options they will be added. 
