### PR TITLE
DependOn supports an array of fields

### DIFF
--- a/lib/src/lib/components/AbstractFormComponent.ts
+++ b/lib/src/lib/components/AbstractFormComponent.ts
@@ -211,15 +211,15 @@ export abstract class FormComponent<S extends Lab900FormField = Lab900FormField>
       .filter((c) => c.dependOn)
       .map((c) => new FieldConditions(this, c))
       .forEach((conditions: FieldConditions) => {
-        const sub = conditions.start(
+        const subs = conditions.start(
           (dependOn: string, value: any, firstRun: boolean) => {
             if (this.onConditionalChange) {
               this.onConditionalChange(dependOn, value, firstRun);
             }
           }
         );
-        if (sub) {
-          this.subscriptions.push(sub);
+        if (subs?.length) {
+          this.subscriptions.concat(subs);
         }
       });
   }

--- a/lib/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -134,8 +134,10 @@ export class SelectFieldComponent
     firstRun: boolean
   ): void {
     setTimeout(() => {
-      const condition = this.schema.conditions.find(
-        (c) => c.dependOn === dependOn
+      const condition = this.schema.conditions.find((c) =>
+        (Array.isArray(c.dependOn) ? c.dependOn : [c.dependOn]).includes(
+          dependOn
+        )
       );
       if (condition?.conditionalOptions) {
         if (!firstRun || !value) {

--- a/src/app/modules/showcase-forms/examples/form-conditionals-example/config/form-conditionals-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-conditionals-example/config/form-conditionals-example.ts
@@ -5,6 +5,7 @@ export const formConditionalsExample: Lab900FormConfig = {
     {
       attribute: 'role',
       editType: EditType.Select,
+      title: 'Role',
       options: {
         colspan: 6,
         selectOptions: [
@@ -21,6 +22,7 @@ export const formConditionalsExample: Lab900FormConfig = {
         {
           attribute: 'country',
           editType: EditType.Select,
+          title: 'Country',
           options: {
             colspan: 6,
           },
@@ -42,14 +44,18 @@ export const formConditionalsExample: Lab900FormConfig = {
         {
           attribute: 'language',
           editType: EditType.Select,
+          title: 'Language',
           options: {
             colspan: 6,
           },
           conditions: [
             {
-              dependOn: 'country',
-              conditionalOptions: (country: string) => {
-                switch (country) {
+              dependOn: ['country', 'role'],
+              conditionalOptions: (value: {
+                country: string;
+                role: string;
+              }) => {
+                switch (value?.country) {
                   case 'BEL':
                     return [
                       { label: 'Dutch', value: 'NL' },
@@ -62,13 +68,15 @@ export const formConditionalsExample: Lab900FormConfig = {
                     return [{ label: 'German', value: 'DE' }];
                 }
               },
-              hideIfEquals: (country: string) => country === 'HIDE',
+              disableIfEquals: (value: { country: string; role: string }) =>
+                value?.country === 'BEL' && value?.role === 'administrator',
             },
           ],
         },
         {
           attribute: 'favouriteFood',
           editType: EditType.Select,
+          title: 'Favourite food',
           options: {
             colspan: 6,
           },


### PR DESCRIPTION
## Purpose

Allow multiple dependencies in one condition

## Approach
- dependOn now also accepts an array of fields 
- conditionals options will return a `Record<fieldName, control>` when an array is defined.

## Example
```
conditions: [
    {
      dependOn: ['country', 'role'],
      conditionalOptions: (value: {
        country: string;
        role: string;
      }) => {
        switch (value?.country) {
          case 'BEL':
            return [
              { label: 'Dutch', value: 'NL' },
              { label: 'French', value: 'FR' },
              { label: 'German', value: 'DE' },
            ];
          case 'FRA':
            return [{ label: 'French', value: 'FR' }];
          case 'GER':
            return [{ label: 'German', value: 'DE' }];
        }
      },
      disableIfEquals: (value: { country: string; role: string }) =>
        value?.country === 'BEL' && value?.role === 'administrator',
    },
],
```