### PR TITLE
Feature/form field info tooltips

### DIFF
--- a/lib/src/lib/components/form-row/form-row.component.html
+++ b/lib/src/lib/components/form-row/form-row.component.html
@@ -28,6 +28,11 @@
           [group]="fieldAttribute ? group.get(fieldAttribute) : group"
           [readonly]="rowIsReadonly(field)"
         ></ng-container>
+        <div class="form-col__info" *ngIf="field?.options?.infoTooltip as tip">
+          <mat-icon [matTooltip]="tip?.text | translate">{{
+            tip?.icon || 'info'
+          }}</mat-icon>
+        </div>
       </div>
     </div>
   </div>

--- a/lib/src/lib/components/form-row/form-row.component.scss
+++ b/lib/src/lib/components/form-row/form-row.component.scss
@@ -7,6 +7,15 @@
   .form-col {
     padding: 0 10px;
     box-sizing: border-box;
+    display: flex;
+
+    &__info {
+      padding: 1em 0 0 0.75em;
+
+      .mat-icon {
+        cursor: help;
+      }
+    }
   }
 
   &:not(.mobile-cols) .form-col {

--- a/lib/src/lib/forms.module.ts
+++ b/lib/src/lib/forms.module.ts
@@ -162,8 +162,14 @@ export class Lab900FormsModule {
     settings: Lab900FormModuleSettings = defaultFormModuleSettings
   ): ModuleWithProviders<FormsModule> {
     const formSetting: Lab900FormModuleSettings = {
-      ...defaultFormModuleSettings,
-      ...settings,
+      formField: {
+        ...defaultFormModuleSettings.formField,
+        ...(settings?.formField ?? {}),
+      },
+      fieldMask: {
+        ...defaultFormModuleSettings.fieldMask,
+        ...(settings?.fieldMask ?? {}),
+      },
     };
     return {
       ngModule: Lab900FormsModule,

--- a/lib/src/lib/models/form-field-base.ts
+++ b/lib/src/lib/models/form-field-base.ts
@@ -47,4 +47,5 @@ export interface FormFieldBaseOptions {
   readonlyDisplay?: (data?: any) => any;
   visibleFn?: (item: any) => boolean;
   onChangeFn?: (value: any) => void;
+  infoTooltip?: { text: string; icon?: string };
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,7 +34,6 @@ export function TranslationLoaderFactory(
     Lab900FormsModule.forRoot({
       formField: {
         appearance: 'fill',
-        showLengthIndicator: true,
       },
     }),
     TranslateModule.forRoot({

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -13,6 +13,9 @@ export const formFieldsExample: Lab900FormConfig = {
           options: {
             colspan: 6,
             required: true,
+            infoTooltip: {
+              text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin id magna et mauris imperdiet imperdiet. Praesent sit amet luctus nulla, vel consequat diam. Fusce luctus mauris mollis justo efficitur, sed posuere purus tempor. Morbi a lectus convallis, interdum sapien nec, finibus enim. Mauris sollicitudin condimentum gravida. Morbi convallis sed ligula eu imperdiet. Praesent tincidunt turpis ut eros placerat, a facilisis nisi volutpat. Cras nisl augue, faucibus eu felis ut, pellentesque sollicitudin risus. Nam feugiat eu risus at volutpat. Nam rutrum finibus lectus id scelerisque. Integer vel feugiat est. Vivamus ipsum mi, pulvinar vitae purus quis, condimentum pellentesque lacus. Nulla facilisi. Donec nec elit tortor. Nunc id placerat mauris, sed placerat purus.',
+            },
           },
         },
         {
@@ -43,7 +46,6 @@ export const formFieldsExample: Lab900FormConfig = {
           editType: EditType.Input,
           options: {
             colspan: 6,
-            readonly: true,
           },
         },
         {
@@ -64,7 +66,7 @@ export const formFieldsExample: Lab900FormConfig = {
           attribute: 'languages',
           editType: EditType.Select,
           options: {
-            readonly: true,
+            infoTooltip: { text: 'dlfdsjflk klsdfjsd kjdfl sdjf ds' },
             colspan: 12,
             selectOptions: [
               {
@@ -76,6 +78,15 @@ export const formFieldsExample: Lab900FormConfig = {
                 label: 'ENG',
               },
             ],
+          },
+        },
+        {
+          title: 'Remark',
+          attribute: 'remark',
+          editType: EditType.TextArea,
+          options: {
+            colspan: 12,
+            infoTooltip: { text: 'dlfdsjflk klsdfjsd kjdfl sdjf ds' },
           },
         },
       ],


### PR DESCRIPTION
## Purpose

An option to add an info button that shows a tooltip

## Approach

Added a new base option "infoTooltip"
` infoTooltip?: { text: string; icon?: string };`

config example:

```
 {
  title: 'Remark',
  attribute: 'remark',
  editType: EditType.TextArea,
  options: {
    infoTooltip: { text: 'some info text' },
  },
},
```

![Schermafbeelding 2021-08-06 om 13 55 19](https://user-images.githubusercontent.com/13655941/128507337-ed26c0db-1abb-46f6-ac17-991135b933c0.png)
