### PR TITLE
bugfix/conditional-select-is-overwritten

### DIFF
--- a/lib/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -148,6 +148,7 @@ export class SelectFieldComponent
       }
     );
   }
+
   public onConditionalChange(
     dependOn: string,
     value: string,


### PR DESCRIPTION
#1
Issue:
When data is set in the form after the form is rendered, the conditional select fields in the form will be reset and their values will be lost.
Solution:
The value of the conditional select is stored before the reset. If the list of items of the select contains the value before the select was reset, it is selected again.
Risks:
When working with infinite scroll, there's no way to know whether the previously selected item existed in the list so it might not be selected
#2
Issue:
Conditional options are retrieved even if enableIfHasValue is true and the field is disabled. As the select items will be reloaded anyway when the condition value changes, this call is unnecessary.
Solution:
A check was added to stop the conditional select options from being loaded when enableIfHasValue is true and the form field is disabled.