### PR TITLE
Partial revert of big refactor which removed valuelabels

### DIFF
--- a/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
+++ b/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
@@ -30,16 +30,21 @@
   <mat-icon matSuffix *ngIf="!fieldIsReadonly">search</mat-icon>
   <mat-autocomplete
     #auto="matAutocomplete"
-    [displayWith]="options.displayInputFn || options.displayOptionFn"
+    [displayWith]="options.displayInputFn"
   >
     <mat-option
       *ngFor="let option of filteredOptions | async"
-      [value]="option"
-      [disabled]="
-        options?.disabledOptionFn ? options.disabledOptionFn(option) : false
-      "
+      [value]="option?.value"
+      [disabled]="option?.disabled"
     >
-      <div [innerHTML]="options.displayOptionFn(option) | translate"></div>
+      <div
+        *ngIf="options?.displayOptionFn"
+        [innerHTML]="options.displayOptionFn(option) | translate"
+      ></div>
+      <div
+        *ngIf="!options?.displayOptionFn"
+        [innerHTML]="option.label | translate"
+      ></div>
     </mat-option>
   </mat-autocomplete>
 </mat-form-field>

--- a/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.ts
+++ b/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.ts
@@ -26,7 +26,7 @@ export class AutocompleteFieldComponent<T>
   @ViewChild('input')
   public autoCompleteInput: ElementRef;
 
-  public filteredOptions: Observable<T[]>;
+  public filteredOptions: Observable<ValueLabel<T>[]>;
 
   public inputChange: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
@@ -48,7 +48,7 @@ export class AutocompleteFieldComponent<T>
       debounceTime(this.options.debounceTime ?? 300),
       switchMap((input: string) => {
         const res = this.options.autocompleteOptions(input, this.fieldControl);
-        return isObservable<T[]>(res) ? res : of(res);
+        return isObservable<ValueLabel<T>[]>(res) ? res : of(res);
       })
     );
   }

--- a/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.model.ts
+++ b/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.model.ts
@@ -8,13 +8,17 @@ import { AbstractControl } from '@angular/forms';
 import { EditType } from '../../../models/editType';
 
 export interface FormFieldAutocompleteOptions<T> extends FormFieldBaseOptions {
-  displayOptionFn: (option: T) => string;
-  displayInputFn?: (option: T) => string;
+  /**
+   *
+   * @deprecated Labels are set in the autocompleteOptions
+   */
+  displayOptionFn?: (option: ValueLabel<T>) => string;
+  displayInputFn: (option: T) => string;
   disabledOptionFn?: (option: T) => boolean;
   autocompleteOptions?: (
     searchTerm: string,
     currentControl: AbstractControl
-  ) => T[] | Observable<T[]>;
+  ) => ValueLabel<T>[] | Observable<ValueLabel<T>[]>;
   debounceTime?: number;
   requireMatch?: boolean;
 }

--- a/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
+++ b/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
@@ -24,7 +24,7 @@
       selectable
       (removed)="remove(i)"
     >
-      <div [innerHTML]="options.displayOptionFn(opt) | translate"></div>
+      <div [innerHTML]="options.displayInputFn(opt) | translate"></div>
       <mat-icon *ngIf="!fieldIsReadonly" matChipRemove>cancel</mat-icon>
     </mat-chip>
     <input
@@ -40,12 +40,16 @@
   <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selected($event)">
     <mat-option
       *ngFor="let option of filteredOptions | async"
-      [value]="option"
-      [disabled]="
-        options?.disabledOptionFn ? options.disabledOptionFn(option) : false
-      "
+      [value]="option?.value"
+      [disabled]="option?.disabled"
     >
-      <div [innerHTML]="options.displayOptionFn(option) | translate"></div>
+      <div
+        *ngIf="options?.displayOptionFn"
+        [innerHTML]="options.displayOptionFn(option) | translate"
+      ></div>
+      <ng-container *ngIf="!options?.displayOptionFn">{{
+        option.label | translate
+      }}</ng-container>
     </mat-option>
   </mat-autocomplete>
 </mat-form-field>

--- a/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.ts
+++ b/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.ts
@@ -33,12 +33,12 @@ export class AutocompleteMultipleFieldComponent<T>
   @ViewChild('auto')
   private matAutocomplete: MatAutocomplete;
 
-  public filteredOptions: Observable<T[]>;
+  public filteredOptions: Observable<ValueLabel<T>[]>;
   public separatorKeysCodes: number[] = [ENTER, COMMA];
 
   public inputChange: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
-  public get selectedOptions(): any[] {
+  public get selectedOptions(): T[] {
     return this.group.controls[this.fieldAttribute]?.value ?? [];
   }
 
@@ -60,7 +60,7 @@ export class AutocompleteMultipleFieldComponent<T>
       debounceTime(this.options.debounceTime ?? 300),
       switchMap((input: string) => {
         const res = this.options.autocompleteOptions(input, this.fieldControl);
-        return isObservable<T[]>(res) ? res : of(res);
+        return isObservable<ValueLabel<T>[]>(res) ? res : of(res);
       })
     );
   }
@@ -82,7 +82,7 @@ export class AutocompleteMultipleFieldComponent<T>
     this.group.markAsDirty();
   }
 
-  private updateControlValue(val: any[]): void {
+  private updateControlValue(val: T[]): void {
     this.group.controls[this.fieldAttribute].setValue(val);
     this.group.controls[this.fieldAttribute].updateValueAndValidity();
     this.group.controls[this.fieldAttribute].markAsDirty();

--- a/lib/src/lib/components/form-fields/select-field/field-select.model.ts
+++ b/lib/src/lib/components/form-fields/select-field/field-select.model.ts
@@ -19,10 +19,18 @@ export interface FormFieldSelectOptions<T> extends FormFieldBaseOptions {
   multiple?: boolean;
   selectOptions?: FormFieldSelectOptionsFn<T> | T[] | Observable<T[]>;
   compareWith?: (o1: T, o2: T) => boolean;
-  displayOptionFn: (option: T) => string;
-  disabledOptionFn?: (option: T) => boolean;
+  /**
+   *
+   * @deprecated Labels are set in the selectOptions ValueLabels
+   */
+  displayOptionFn?: (option: ValueLabel<T>) => string;
   customTriggerFn?: (value: T) => string;
   autoselectOnlyOption?: boolean;
+  /**
+   * The function to display the current value of the select if this item is not present in the select options.
+   * @param option Expects the current value of the field, not a ValueLabel!
+   */
+  displaySelectedOptionFn?: (option: T) => string;
   search?: {
     enabled: boolean;
     placeholder?: string;

--- a/lib/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.html
@@ -51,12 +51,17 @@
     </mat-option>
     <mat-option
       *ngFor="let item of selectOptions"
-      [value]="item"
-      [disabled]="
-        options?.disabledOptionFn ? options.disabledOptionFn(item) : false
-      "
+      [value]="item.value"
+      [disabled]="item.disabled"
     >
-      <div [innerHTML]="options?.displayOptionFn(item) | translate"></div>
+      <div
+        *ngIf="options?.displayOptionFn"
+        [innerHTML]="options.displayOptionFn(item) | translate"
+      ></div>
+      <div
+        *ngIf="!options?.displayOptionFn"
+        [innerHTML]="item.label | translate"
+      ></div>
     </mat-option>
   </mat-select>
   <mat-hint
@@ -74,13 +79,17 @@
     class="lab900-readonly-field__label"
     >{{ options?.readonlyLabel || schema.title | translate }}</span
   >
-  <div *ngIf="!loading || !fieldControl.value">
-    {{
+  <div
+    *ngIf="!loading || !fieldControl.value"
+    [innerHTML]="
       selectedOption
-        ? (options?.displayOptionFn(selectedOption) | translate)
+        ? ((options?.displayOptionFn
+            ? options?.displayOptionFn(selectedOption.value)
+            : selectedOption.label
+          ) | translate)
         : '-'
-    }}
-  </div>
+    "
+  ></div>
   <div *ngIf="loading && fieldControl.value">
     {{ 'form.field.loading' | translate }}
   </div>

--- a/lib/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -17,6 +17,7 @@ import {
 } from './field-select.model';
 import { IFieldConditions } from '../../../models/IFieldConditions';
 import { coerceArray } from '@lab900/ui';
+import { ValueLabel } from '../../../models/form-field-base';
 
 @Component({
   selector: 'lab900-select-field',
@@ -30,7 +31,7 @@ export class SelectFieldComponent<T>
    * When conditional options are used for this select, keep the previously selected item
    * and select it again when the new valuelist is loaded
    */
-  private conditionalItemToSelectWhenExists: any;
+  private conditionalItemToSelectWhenExists: T;
 
   private conditionalOptionsChange = new Subject<{
     condition: IFieldConditions;
@@ -45,16 +46,16 @@ export class SelectFieldComponent<T>
   @HostBinding('class')
   public classList = 'lab900-form-field';
 
-  public selectOptions: T[];
+  public selectOptions: ValueLabel<T>[];
 
   public loading = true;
 
-  public get selectedOption(): T {
+  public get selectedOption(): ValueLabel<T> {
     if (this.selectOptions && this.fieldControl.value) {
       return this.selectOptions.find((opt) =>
         this.options?.compareWith
-          ? this.options?.compareWith(opt, this.fieldControl.value)
-          : this.defaultCompare(opt, this.fieldControl.value)
+          ? this.options?.compareWith(opt.value, this.fieldControl.value)
+          : this.defaultCompare(opt.value, this.fieldControl.value)
       );
     }
     return null;
@@ -97,13 +98,13 @@ export class SelectFieldComponent<T>
               const values = getOptions(optionsFilter);
               return (isObservable(values) ? values : of(values)).pipe(
                 catchError(() => of([])),
-                tap((options) => {
+                tap((options: ValueLabel<T>[]) => {
                   if (
                     options.length === 1 &&
                     !this.fieldControl.value &&
                     this.schema.options?.autoselectOnlyOption
                   ) {
-                    this.fieldControl.setValue(options[0]);
+                    this.fieldControl.setValue(options[0].value);
                   }
                 })
               );
@@ -111,7 +112,7 @@ export class SelectFieldComponent<T>
           )
         )
       ),
-      (options) => {
+      (options: ValueLabel<T>[]) => {
         const compare = this.options?.compareWith || this.defaultCompare;
 
         if (this.optionsFilter$.value?.page > 0) {
@@ -121,7 +122,7 @@ export class SelectFieldComponent<T>
            */
           this.selectOptions = this.selectOptions.concat(
             options.filter((o) =>
-              this.selectOptions.some((so) => !compare(o, so))
+              this.selectOptions.some((so) => !compare(o.value, so.value))
             )
           );
         } else {
@@ -132,7 +133,7 @@ export class SelectFieldComponent<T>
           const value = coerceArray(this.conditionalItemToSelectWhenExists);
           const compare = this.options?.compareWith || this.defaultCompare;
           const inOptions = this.selectOptions.some((o) =>
-            value.some((v) => compare(o, v))
+            value.some((v) => compare(o.value, v))
           );
           if (inOptions) {
             this.fieldControl.setValue(this.conditionalItemToSelectWhenExists);
@@ -148,10 +149,23 @@ export class SelectFieldComponent<T>
           const value = coerceArray(this.fieldControl.value);
           const compare = this.options?.compareWith || this.defaultCompare;
           const inOptions = this.selectOptions.some((o) =>
-            value.some((v) => compare(o, v))
+            value.some((v) => compare(o.value, v))
           );
           if (!inOptions) {
-            this.selectOptions = value.concat(this.selectOptions);
+            let label;
+            // TODO: Validate options, this is a required field if search or infinite scroll is used
+            if (!this.options?.displaySelectedOptionFn) {
+              label = "ERROR: Can't display";
+              console.error(
+                'Please define a displaySelectedOptionFn to display your currently selected option since it is not included in the current options'
+              );
+            }
+            this.selectOptions = value
+              .map((v: T) => ({
+                value: v,
+                label: label ?? this.options.displaySelectedOptionFn(v),
+              }))
+              .concat(this.selectOptions);
           }
         }
 

--- a/lib/src/lib/models/editType.ts
+++ b/lib/src/lib/models/editType.ts
@@ -6,7 +6,7 @@ export enum EditType {
   Input = 'Input',
   /**
    *
-   * @deprecated in favor of {@link FilePreview}
+   * @deprecated Deprecated in favor of {@link FilePreview}
    */
   File = 'File',
   FilePreview = 'FilePreview',
@@ -16,7 +16,15 @@ export enum EditType {
   RadioButtons = 'RadioButtons',
   RangeSlider = 'RangeSlider',
   Row = 'Row',
+  /**
+   *
+   * @deprecated Please use {@link Select} instead with search option
+   */
   Autocomplete = 'Autocomplete',
+  /**
+   *
+   * @deprecated Please use {@link Select} instead with search option
+   */
   AutocompleteMultiple = 'AutocompleteMultiple',
   Icon = 'Icon',
   ButtonToggle = 'ButtonToggle',

--- a/src/app/modules/showcase-forms/examples/form-condtional-validation-example/form-condtional-validation-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-condtional-validation-example/form-condtional-validation-example.component.ts
@@ -44,7 +44,6 @@ export class FormCondtionalValidationExampleComponent {
         editType: EditType.Select,
         title: 'Select Field?',
         options: {
-          displayOptionFn: (value: ValueLabel) => value.label,
           colspan: 6,
           selectOptions: [
             { value: 'a', label: 'Option a' },

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-example.component.ts
@@ -21,7 +21,12 @@ export class FormFieldAutocompleteExampleComponent {
     { name: 'Mary' },
     { name: 'Shelley' },
     { name: 'Igor' },
-  ].map((value) => ({ value, label: value.name }));
+  ].map((value) => {
+    const image =
+      'https://firebasestorage.googleapis.com/v0/b/lab900-website-production.appspot.com/o/public%2Fproject-images%2Fyou%2Fyou-mockup.svg?alt=media';
+    const label = `<div class="user-option"><img width="20" height="20" src="${image}"> ${value.name}</div>`;
+    return { value, label };
+  });
 
   public formSchema: Lab900FormConfig = {
     fields: [
@@ -33,13 +38,7 @@ export class FormFieldAutocompleteExampleComponent {
           required: true,
           autocompleteOptions: (value: string) => of(this.filter(value)),
           debounceTime: 500,
-          displayInputFn: (user: ValueLabel) => user?.label ?? '',
-          displayOptionFn: (user: ValueLabel) => {
-            const userName = user?.label ?? '';
-            const image =
-              'https://firebasestorage.googleapis.com/v0/b/lab900-website-production.appspot.com/o/public%2Fproject-images%2Fyou%2Fyou-mockup.svg?alt=media';
-            return `<div class="user-option"><img width="20" height="20" src="${image}"> ${userName}</div>`;
-          },
+          displayInputFn: (user: { name: string }) => user?.name ?? '',
         },
       },
       {
@@ -50,13 +49,7 @@ export class FormFieldAutocompleteExampleComponent {
           autocompleteOptions: (value: string) => of(this.filter(value)),
           debounceTime: 500,
           requireMatch: true,
-          displayInputFn: (user: ValueLabel) => user?.label ?? '',
-          displayOptionFn: (user: ValueLabel) => {
-            const userName = user?.label ?? '';
-            const image =
-              'https://firebasestorage.googleapis.com/v0/b/lab900-website-production.appspot.com/o/public%2Fproject-images%2Fyou%2Fyou-mockup.svg?alt=media';
-            return `<div class="user-option"><img width="20" height="20" src="${image}"> ${userName}</div>`;
-          },
+          displayInputFn: (user: { name: string }) => user?.name ?? '',
         },
       },
     ],

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
@@ -21,7 +21,7 @@ export class FormFieldAutocompleteMultipleExampleComponent {
         editType: EditType.AutocompleteMultiple,
         options: {
           autocompleteOptions: (value: string) => of(this.filter(value)),
-          displayOptionFn: (user: ValueLabel) => user?.label,
+          displayInputFn: (user: { name: string }) => user?.name,
         },
       },
     ],

--- a/src/app/modules/showcase-forms/examples/form-field-select-example/form-field-select-advanced-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-select-example/form-field-select-advanced-example.component.ts
@@ -3,6 +3,7 @@ import {
   EditType,
   FormFieldSelectOptionsFilter,
   Lab900FormConfig,
+  ValueLabel,
 } from '@lab900/forms';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
@@ -48,9 +49,9 @@ export class FormFieldSelectAdvancedExampleComponent {
             editType: EditType.Select,
             options: {
               compareWith: compare,
-              displayOptionFn: (o: Book) => o?.title,
               selectOptions: this.getSelectOptions.bind(this),
               colspan: 4,
+              displaySelectedOptionFn: (o: Book) => o?.title,
               infiniteScroll: {
                 enabled: true,
               },
@@ -62,9 +63,9 @@ export class FormFieldSelectAdvancedExampleComponent {
             editType: EditType.Select,
             options: {
               compareWith: compare,
-              displayOptionFn: (o: Book) => o?.title,
               selectOptions: this.getSelectOptions.bind(this),
               colspan: 4,
+              displaySelectedOptionFn: (o: Book) => o?.title,
               infiniteScroll: {
                 enabled: true,
               },
@@ -79,13 +80,13 @@ export class FormFieldSelectAdvancedExampleComponent {
             editType: EditType.Select,
             options: {
               compareWith: compare,
-              displayOptionFn: (o: Book) => o?.title,
-              customTriggerFn: (value: any[]) => {
+              customTriggerFn: (value: Book[]) => {
                 return value?.length + ' selected';
               },
               selectOptions: this.getSelectOptions.bind(this),
               colspan: 4,
               multiple: true,
+              displaySelectedOptionFn: (o: Book) => o?.title,
               infiniteScroll: {
                 enabled: true,
               },
@@ -105,14 +106,12 @@ export class FormFieldSelectAdvancedExampleComponent {
             title: 'Select an author',
             editType: EditType.Select,
             options: {
-              displayOptionFn: (value: Book) => value.title,
-              disabledOptionFn: (value: Book) => value.key === 'martin',
               selectOptions: [
-                { key: 'twain', title: 'Twain' },
-                { key: 'tolkien', title: 'Tolkien' },
+                { value: 'twain', label: 'Twain' },
+                { value: 'tolkien', label: 'Tolkien' },
                 {
-                  key: 'martin',
-                  title: 'George R. R. Martin',
+                  value: 'martin',
+                  label: 'George R. R. Martin',
                   disabled: true,
                 },
               ],
@@ -124,10 +123,10 @@ export class FormFieldSelectAdvancedExampleComponent {
             title: 'Search a book',
             editType: EditType.Select,
             options: {
-              displayOptionFn: (value: Book) => value.title,
               selectOptions: this.getSelectOptions.bind(this),
               compareWith: compare,
               colspan: 6,
+              displaySelectedOptionFn: (value: Book) => value.title,
               infiniteScroll: {
                 enabled: true,
               },
@@ -155,7 +154,7 @@ export class FormFieldSelectAdvancedExampleComponent {
   public getSelectOptions(
     filter?: FormFieldSelectOptionsFilter,
     author?: string
-  ): Observable<{ title: string; key: string }[]> {
+  ): Observable<ValueLabel<{ title: string; key: string }>[]> {
     return this.http
       .get<{ docs: any[] }>('https://openlibrary.org/search.json', {
         params: {
@@ -165,6 +164,13 @@ export class FormFieldSelectAdvancedExampleComponent {
           offset: String((filter?.page || 0) * 10),
         },
       })
-      .pipe(map((res) => res?.docs));
+      .pipe(
+        map((res) =>
+          res?.docs?.map((d) => ({
+            label: d.title,
+            value: d,
+          }))
+        )
+      );
   }
 }

--- a/src/app/modules/showcase-forms/examples/form-field-select-example/form-field-select-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-select-example/form-field-select-example.component.ts
@@ -39,7 +39,6 @@ export class FormFieldSelectExampleComponent {
             title: 'Select yes or no',
             editType: EditType.Select,
             options: {
-              displayOptionFn: (value: ValueLabel) => value.label,
               selectOptions: [
                 {
                   value: true,
@@ -58,7 +57,6 @@ export class FormFieldSelectExampleComponent {
             title: 'Only item is auto-selected',
             editType: EditType.Select,
             options: {
-              displayOptionFn: (value: ValueLabel) => value.label,
               selectOptions: [
                 {
                   value: 'only',
@@ -79,7 +77,6 @@ export class FormFieldSelectExampleComponent {
             title: 'Select yes or no',
             editType: EditType.Select,
             options: {
-              displayOptionFn: (value: ValueLabel) => value.label,
               colspan: 6,
               selectOptions: [
                 {


### PR DESCRIPTION
- Changed type of select options back to valueLabel list
- Added extra display function to display the current selected option if it is not included in the select options
- Deprecated old displayOptionFn because it is not needed with valueLabels