### PR TITLE
feat: add readonly container class option to form fields

### DIFF
--- a/lib/src/lib/components/form-fields/readonly-field/readonly-field.component.html
+++ b/lib/src/lib/components/form-fields/readonly-field/readonly-field.component.html
@@ -1,6 +1,12 @@
-<div class="lab900-readonly-field" *ngIf="!fieldIsHidden">
-  <span *ngIf="options?.readonlyLabel || schema.title" class="lab900-readonly-field__label">{{
-    options?.readonlyLabel || schema.title | translate
-  }}</span>
+<div
+  class="lab900-readonly-field"
+  [class]="options.readonlyContainerClass"
+  *ngIf="!fieldIsHidden"
+>
+  <span
+    *ngIf="options?.readonlyLabel || schema.title"
+    class="lab900-readonly-field__label"
+    >{{ options?.readonlyLabel || schema.title | translate }}</span
+  >
   <div [innerHTML]="value || '-' | translate"></div>
 </div>

--- a/lib/src/lib/models/form-field-base.ts
+++ b/lib/src/lib/models/form-field-base.ts
@@ -44,6 +44,7 @@ export interface FormFieldBaseOptions {
   max?: number;
   defaultValue?: any;
   pattern?: RegExp;
+  readonlyContainerClass?: string;
   readonlyLabel?: string;
   readonlyDisplay?: (data?: any) => any;
   visibleFn?: (item: any) => boolean;

--- a/src/app/modules/showcase-forms/examples/form-field-inputs-example/form-field-inputs-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-inputs-example/form-field-inputs-example.component.ts
@@ -13,6 +13,21 @@ export class FormFieldInputsExampleComponent {
   public formSchema: Lab900FormConfig = {
     fields: [
       {
+        editType: EditType.Row,
+        nestedFields: [
+          {
+            attribute: 'containerCustomClass',
+            editType: EditType.Input,
+            options: {
+              readonly: true,
+              readonlyContainerClass: 'readonlyInputCustomContainerClass',
+              defaultValue: 'MANUAL',
+            },
+          },
+        ],
+      },
+
+      {
         attribute: 'uniqueNumber',
         title: 'Text Input Hidden',
         editType: EditType.Input,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -123,3 +123,12 @@ pre[class*='language-'] {
     padding: 15px;
   }
 }
+
+.readonlyInputCustomContainerClass {
+  max-width: fit-content;
+  padding: 5px 15px;
+  color: #737d99;
+  background-color: rgba($color: #737d99, $alpha: 0.5);
+  font-size: 12px;
+  margin-bottom: 19px;
+}


### PR DESCRIPTION
To add a readonly container class option to form fields
<img width="827" alt="Screenshot 2022-02-07 at 12 20 33" src="https://user-images.githubusercontent.com/77984527/152787083-9748d10f-0a88-4850-801b-87ef6deff1c0.png">

