### PR TITLE
Feature/amount field

### DIFF
--- a/lib/src/lib/components/AbstractFormComponent.ts
+++ b/lib/src/lib/components/AbstractFormComponent.ts
@@ -169,6 +169,16 @@ export abstract class FormComponent<S extends Lab900FormField = Lab900FormField>
           'forms.error.requireMatch',
           interpolateParams
         );
+      case 'toManyDecimalSeparators':
+        return this.translateService.get(
+          'forms.error.toManyDecimalSeparators',
+          interpolateParams
+        );
+      case 'invalidNumber':
+        return this.translateService.get(
+          'forms.error.invalidNumber',
+          interpolateParams
+        );
       default:
         return this.translateService.get(
           'forms.error.generic',

--- a/lib/src/lib/components/form-fields/amount-field/amount-field.component.html
+++ b/lib/src/lib/components/form-fields/amount-field/amount-field.component.html
@@ -48,7 +48,7 @@
   >
     <span [innerHTML]="hint | translate: hintValueTranslateData"></span>
   </mat-hint>
-  <mat-error *ngIf="!valid && !fieldIsReadonly"
-    ><span [innerHTML]="getErrorMessage() | async"></span
-  ></mat-error>
+  <mat-error *ngIf="!valid && !fieldIsReadonly">
+    <span [innerHTML]="getErrorMessage() | async"></span>
+  </mat-error>
 </mat-form-field>

--- a/lib/src/lib/components/form-fields/amount-field/amount-field.component.html
+++ b/lib/src/lib/components/form-fields/amount-field/amount-field.component.html
@@ -1,0 +1,54 @@
+<mat-form-field
+  *ngIf="!fieldIsHidden"
+  [formGroup]="group"
+  class="lab900-input-field {{ options?.align || 'left' }}"
+  [class.spanFix]="options?.suffix || options?.prefix"
+  id="lab900-input-field-{{ fieldAttribute }}"
+>
+  <mat-label *ngIf="schema.title">{{ schema.title | translate }}</mat-label>
+  <input
+    matInput
+    #input
+    type="text"
+    placeholder="{{ placeholder | translate }}"
+    [formControlName]="fieldAttribute"
+    [required]="fieldIsRequired"
+    [readonly]="fieldIsReadonly"
+    [ngClass]="{ readonly: fieldIsReadonly }"
+    lab900InputAutofocus
+    lab900AmountInput
+    [autofocus]="options?.autofocus"
+    [style]="options?.style || ''"
+    [maxDecimals]="options?.maxDecimals"
+    [minDecimals]="options?.minDecimals"
+  />
+  <lab900-icon
+    [icon]="schema.icon"
+    *ngIf="schema?.icon?.position === 'left'"
+    matPrefix
+    class="input-field__icon-left"
+  ></lab900-icon>
+  <lab900-icon
+    [icon]="schema.icon"
+    *ngIf="schema?.icon?.position === 'right'"
+    matSuffix
+  ></lab900-icon>
+  <span class="lab900-input-field--suffix" *ngIf="suffix" matSuffix>{{
+    suffix | translate
+  }}</span>
+  <span class="lab900-input-field--prefix" *ngIf="prefix" matPrefix>{{
+    prefix | translate
+  }}</span>
+  <mat-hint
+    *ngIf="
+      hint &&
+      !(schema.options.hint.hideHintOnValidValue && input.value) &&
+      !fieldIsReadonly
+    "
+  >
+    <span [innerHTML]="hint | translate: hintValueTranslateData"></span>
+  </mat-hint>
+  <mat-error *ngIf="!valid && !fieldIsReadonly"
+    ><span [innerHTML]="getErrorMessage() | async"></span
+  ></mat-error>
+</mat-form-field>

--- a/lib/src/lib/components/form-fields/amount-field/amount-field.component.scss
+++ b/lib/src/lib/components/form-fields/amount-field/amount-field.component.scss
@@ -1,0 +1,11 @@
+.lab900-input-field {
+  &__icon {
+    &-left {
+      margin-right: 2px;
+    }
+  }
+
+  &.right input {
+    text-align: right;
+  }
+}

--- a/lib/src/lib/components/form-fields/amount-field/amount-field.component.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount-field.component.ts
@@ -1,0 +1,40 @@
+import { Component, HostBinding, Inject } from '@angular/core';
+import { FormComponent } from '../../AbstractFormComponent';
+import {
+  LAB900_FORM_MODULE_SETTINGS,
+  Lab900FormModuleSettings,
+} from '../../../models/Lab900FormModuleSettings';
+import { TranslateService } from '@ngx-translate/core';
+import { FormFieldAmount } from './amount-field.model';
+
+@Component({
+  selector: 'lab900-amount-field',
+  templateUrl: './amount-field.component.html',
+  styleUrls: ['./amount-field.component.scss'],
+})
+export class AmountFieldComponent extends FormComponent<FormFieldAmount> {
+  @HostBinding('class')
+  public classList = `lab900-form-field`;
+
+  public get suffix(): string {
+    if (typeof this.options?.suffix === 'function') {
+      return this.options.suffix(this.group.value);
+    }
+    return this.options?.suffix;
+  }
+
+  public get prefix(): string {
+    if (typeof this.options?.prefix === 'function') {
+      return this.options.prefix(this.group.value);
+    }
+    return this.options?.prefix;
+  }
+
+  public constructor(
+    @Inject(LAB900_FORM_MODULE_SETTINGS)
+    public setting: Lab900FormModuleSettings,
+    translateService: TranslateService
+  ) {
+    super(translateService);
+  }
+}

--- a/lib/src/lib/components/form-fields/amount-field/amount-field.model.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount-field.model.ts
@@ -5,14 +5,19 @@ import {
   Icon,
 } from '../../../models/form-field-base';
 
-export interface AmountFieldInputOptions extends FormFieldBaseOptions {
+export interface AmountOptions extends FormFieldBaseOptions {
+  maxDecimals?: number;
+  minDecimals?: number;
+}
+
+export interface AmountFieldInputOptions
+  extends AmountOptions,
+    FormFieldBaseOptions {
   autofocus?: boolean;
   suffix?: string | ((data?: any) => string);
   prefix?: string | ((data?: any) => string);
   align?: 'left' | 'right';
   style?: string;
-  maxDecimals?: number; // default is 2
-  minDecimals?: number; // default is 0
 }
 
 export interface FormFieldAmount<T extends string | number = string>

--- a/lib/src/lib/components/form-fields/amount-field/amount-field.model.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount-field.model.ts
@@ -1,0 +1,22 @@
+import { EditType } from '../../../models/editType';
+import {
+  FormFieldBase,
+  FormFieldBaseOptions,
+  Icon,
+} from '../../../models/form-field-base';
+
+export interface AmountFieldInputOptions extends FormFieldBaseOptions {
+  autofocus?: boolean;
+  suffix?: string | ((data?: any) => string);
+  prefix?: string | ((data?: any) => string);
+  align?: 'left' | 'right';
+  style?: string;
+  maxDecimals?: number; // default is 2
+  minDecimals?: number; // default is 0
+}
+
+export interface FormFieldAmount<T extends string | number = string>
+  extends FormFieldBase<T, AmountFieldInputOptions> {
+  editType: EditType.Amount;
+  icon?: Icon & { position?: 'left' | 'right' };
+}

--- a/lib/src/lib/components/form-fields/amount-field/amount-input.directive.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount-input.directive.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import {
   amountToNumber,
+  formatAmountWithoutRounding,
   getAmountFormatter,
   validateNumberInput,
 } from './amount.helpers';
@@ -87,7 +88,13 @@ export class AmountInputDirective
     if (this.ngControl.value) {
       const v = amountToNumber(String(this.ngControl.value)) ?? null;
       this.ngControl.control?.setValue(
-        v != null ? this.formatter.format(v) : '',
+        v != null
+          ? formatAmountWithoutRounding(
+              v,
+              this.formatter,
+              this.getMaxDecimals()
+            )
+          : '',
         { emitEvent: false }
       );
     }
@@ -102,8 +109,16 @@ export class AmountInputDirective
 
   private getFormatter(): Intl.NumberFormat {
     return getAmountFormatter(this.locale, {
-      maxDecimals: this.maxDecimals ?? this.setting?.amountField?.maxDecimals,
-      minDecimals: this.minDecimals ?? this.setting?.amountField?.minDecimals,
+      maxDecimals: this.getMaxDecimals(),
+      minDecimals: this.getMinDecimals(),
     });
+  }
+
+  private getMaxDecimals(): number {
+    return this.maxDecimals ?? this.setting?.amountField?.maxDecimals;
+  }
+
+  private getMinDecimals(): number {
+    return this.minDecimals ?? this.setting?.amountField?.minDecimals;
   }
 }

--- a/lib/src/lib/components/form-fields/amount-field/amount-input.directive.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount-input.directive.ts
@@ -14,6 +14,8 @@ import {
   amountToNumber,
   formatAmountWithoutRounding,
   getAmountFormatter,
+  getDecimalSeparator,
+  getThousandSeparator,
   validateNumberInput,
 } from './amount.helpers';
 import { Subscription } from 'rxjs';
@@ -41,6 +43,9 @@ export class AmountInputDirective
   public minDecimals?: number;
 
   private readonly locale: string;
+  private readonly decimalSeparator: string;
+  private readonly thousandSeparator: string;
+
   private formatter: Intl.NumberFormat;
 
   public constructor(
@@ -50,7 +55,10 @@ export class AmountInputDirective
     @Self() private ngControl: NgControl
   ) {
     this.locale = setting?.amountField?.locale ?? appLocale;
+    this.decimalSeparator = getDecimalSeparator(this.locale);
+    this.thousandSeparator = getThousandSeparator(this.locale);
     this.formatter = this.getFormatter();
+    console.log(this);
   }
 
   public ngOnChanges(changes: SimpleChanges): void {
@@ -102,7 +110,10 @@ export class AmountInputDirective
 
   private unFormatValue(): void {
     if (this.ngControl.value) {
-      const value = String(this.ngControl.value).replace(/\./g, '');
+      const value = String(this.ngControl.value).replace(
+        new RegExp('\\' + this.thousandSeparator, 'g'),
+        ''
+      );
       this.ngControl.control?.setValue(value ?? '', { emitEvent: false });
     }
   }

--- a/lib/src/lib/components/form-fields/amount-field/amount-input.directive.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount-input.directive.ts
@@ -30,7 +30,7 @@ export class AmountInputDirective
   implements OnChanges, AfterViewInit, OnDestroy
 {
   private readonly validator = validateNumberInput();
-  private focusMode = false;
+  public focusMode = false;
   private changeSub?: Subscription;
 
   @Input()

--- a/lib/src/lib/components/form-fields/amount-field/amount-input.directive.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount-input.directive.ts
@@ -10,7 +10,11 @@ import {
   Self,
   SimpleChanges,
 } from '@angular/core';
-import { amountToNumber, validateNumberInput } from './amount.helpers';
+import {
+  amountToNumber,
+  getAmountFormatter,
+  validateNumberInput,
+} from './amount.helpers';
 import { Subscription } from 'rxjs';
 import { NgControl } from '@angular/forms';
 import { filter } from 'rxjs/operators';
@@ -39,7 +43,7 @@ export class AmountInputDirective
   private formatter: Intl.NumberFormat;
 
   public constructor(
-    @Inject(LOCALE_ID) public appLocale: string,
+    @Inject(LOCALE_ID) appLocale: string,
     @Inject(LAB900_FORM_MODULE_SETTINGS)
     public setting: Lab900FormModuleSettings,
     @Self() private ngControl: NgControl
@@ -97,11 +101,9 @@ export class AmountInputDirective
   }
 
   private getFormatter(): Intl.NumberFormat {
-    return new Intl.NumberFormat(this.locale, {
-      maximumFractionDigits:
-        this.maxDecimals ?? this.setting?.amountField?.maxDecimals,
-      minimumFractionDigits:
-        this.minDecimals ?? this.setting?.amountField?.minDecimals,
+    return getAmountFormatter(this.locale, {
+      maxDecimals: this.maxDecimals ?? this.setting?.amountField?.maxDecimals,
+      minDecimals: this.minDecimals ?? this.setting?.amountField?.minDecimals,
     });
   }
 }

--- a/lib/src/lib/components/form-fields/amount-field/amount-input.directive.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount-input.directive.ts
@@ -1,0 +1,107 @@
+import {
+  AfterViewInit,
+  Directive,
+  HostListener,
+  Inject,
+  Input,
+  LOCALE_ID,
+  OnChanges,
+  OnDestroy,
+  Self,
+  SimpleChanges,
+} from '@angular/core';
+import { amountToNumber, validateNumberInput } from './amount.helpers';
+import { Subscription } from 'rxjs';
+import { NgControl } from '@angular/forms';
+import { filter } from 'rxjs/operators';
+import {
+  LAB900_FORM_MODULE_SETTINGS,
+  Lab900FormModuleSettings,
+} from '../../../models/Lab900FormModuleSettings';
+
+@Directive({
+  selector: '[lab900AmountInput]',
+})
+export class AmountInputDirective
+  implements OnChanges, AfterViewInit, OnDestroy
+{
+  private readonly validator = validateNumberInput();
+  private focusMode = false;
+  private changeSub?: Subscription;
+
+  @Input()
+  public maxDecimals?: number;
+
+  @Input()
+  public minDecimals?: number;
+
+  private readonly locale: string;
+  private formatter: Intl.NumberFormat;
+
+  public constructor(
+    @Inject(LOCALE_ID) public appLocale: string,
+    @Inject(LAB900_FORM_MODULE_SETTINGS)
+    public setting: Lab900FormModuleSettings,
+    @Self() private ngControl: NgControl
+  ) {
+    this.locale = setting?.amountField?.locale ?? appLocale;
+    this.formatter = this.getFormatter();
+  }
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes?.maxDecimals || changes?.minDecimals) {
+      this.formatter = this.getFormatter();
+    }
+  }
+
+  public ngAfterViewInit(): void {
+    this.formatValue();
+    this.changeSub = this.ngControl?.control?.valueChanges
+      .pipe(filter(() => !this.focusMode))
+      .subscribe(this.formatValue.bind(this));
+  }
+
+  public ngOnDestroy(): void {
+    this.changeSub?.unsubscribe();
+  }
+
+  @HostListener('focus')
+  public onFocus(): void {
+    this.focusMode = true;
+    this.ngControl?.control?.addValidators(this.validator);
+    this.unFormatValue();
+  }
+
+  @HostListener('blur')
+  public onBlur(): void {
+    this.focusMode = false;
+    this.ngControl?.control?.removeValidators(this.validator);
+    this.formatValue();
+  }
+
+  private formatValue(): void {
+    if (this.ngControl.value) {
+      const v = amountToNumber(String(this.ngControl.value)) ?? null;
+      this.ngControl.control?.setValue(
+        v != null ? this.formatter.format(v) : '',
+        { emitEvent: false }
+      );
+    }
+  }
+
+  private unFormatValue(): void {
+    if (this.ngControl.value) {
+      const value = String(this.ngControl.value).replace(/\./g, '');
+      this.ngControl.control?.setValue(value ?? '', { emitEvent: false });
+    }
+  }
+
+  private getFormatter(): Intl.NumberFormat {
+    return new Intl.NumberFormat(this.locale, {
+      maximumFractionDigits:
+        this.maxDecimals ?? this.setting?.amountField?.maxDecimals,
+      minimumFractionDigits:
+        this.minDecimals ?? this.setting?.amountField?.minDecimals,
+    });
+  }
+}

--- a/lib/src/lib/components/form-fields/amount-field/amount.helpers.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount.helpers.ts
@@ -1,4 +1,5 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { AmountOptions } from './amount-field.model';
 
 export function getSeparatorCount(value: string, separator: string): number {
   return value?.match(new RegExp(separator, 'g'))?.length ?? 0;
@@ -42,4 +43,14 @@ export function validateNumberInput(): ValidatorFn {
     });
     return error;
   };
+}
+
+export function getAmountFormatter(
+  locale: string,
+  options?: AmountOptions
+): Intl.NumberFormat {
+  return new Intl.NumberFormat(locale, {
+    maximumFractionDigits: options?.maxDecimals,
+    minimumFractionDigits: options?.minDecimals,
+  });
 }

--- a/lib/src/lib/components/form-fields/amount-field/amount.helpers.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount.helpers.ts
@@ -1,0 +1,45 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export function getSeparatorCount(value: string, separator: string): number {
+  return value?.match(new RegExp(separator, 'g'))?.length ?? 0;
+}
+
+export function amountToNumber(
+  value: string,
+  errorCb?: (error: string) => null
+): number | null {
+  if (value?.length) {
+    const commaCount = getSeparatorCount(value, ',');
+    const pointCount = getSeparatorCount(value, '\\.');
+    // the input value can only contain one separator sign
+    if (commaCount + pointCount > 1) {
+      return errorCb ? errorCb('toManyDecimalSeparators') : null;
+    }
+    // replace comma by point to validate the string as a valid number
+    if (!pointCount && commaCount) {
+      value = value.replace(',', '.');
+    }
+    if (Number.isNaN(+value)) {
+      return errorCb ? errorCb('invalidNumber') : null;
+    }
+    return +value;
+  }
+  return null;
+}
+
+export function validateNumberInput(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    let value = control.value;
+
+    if (!value?.length) {
+      return null;
+    }
+
+    let error: ValidationErrors | null = null;
+    amountToNumber(value, (e) => {
+      error = { [e]: true };
+      return null;
+    });
+    return error;
+  };
+}

--- a/lib/src/lib/components/form-fields/amount-field/amount.helpers.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount.helpers.ts
@@ -54,3 +54,12 @@ export function getAmountFormatter(
     minimumFractionDigits: options?.minDecimals,
   });
 }
+
+export function formatAmountWithoutRounding(
+  value: number,
+  formatter: Intl.NumberFormat,
+  max: number = 0
+): string {
+  const re = new RegExp('^-?\\d+(?:.\\d{0,' + (max || -1) + '})?');
+  return formatter.format(+value.toString().match(re)[0]);
+}

--- a/lib/src/lib/components/form-fields/amount-field/amount.helpers.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount.helpers.ts
@@ -63,3 +63,13 @@ export function formatAmountWithoutRounding(
   const re = new RegExp('^-?\\d+(?:.\\d{0,' + (max || -1) + '})?');
   return formatter.format(+value.toString().match(re)[0]);
 }
+
+export function getDecimalSeparator(locale: string): string {
+  const numberWithDecimalSeparator = 1.1;
+  return numberWithDecimalSeparator.toLocaleString(locale).substring(1, 2);
+}
+
+export function getThousandSeparator(locale: string): string {
+  const numberWithDecimalSeparator = 1000;
+  return numberWithDecimalSeparator.toLocaleString(locale).substring(1, 2);
+}

--- a/lib/src/lib/components/form-fields/amount-field/amount.pipe.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount.pipe.ts
@@ -4,7 +4,10 @@ import {
   LAB900_FORM_MODULE_SETTINGS,
   Lab900FormModuleSettings,
 } from '../../../models/Lab900FormModuleSettings';
-import { getAmountFormatter } from './amount.helpers';
+import {
+  formatAmountWithoutRounding,
+  getAmountFormatter,
+} from './amount.helpers';
 
 @Pipe({
   name: 'amount',
@@ -21,12 +24,13 @@ export class AmountPipe implements PipeTransform {
   }
 
   public transform(value: number, options?: AmountOptions): string {
+    const maxDecimals =
+      options?.maxDecimals ?? this.setting?.amountField?.maxDecimals;
     const formatter = getAmountFormatter(this.locale, {
-      maxDecimals:
-        options?.maxDecimals ?? this.setting?.amountField?.maxDecimals,
+      maxDecimals,
       minDecimals:
         options?.minDecimals ?? this.setting?.amountField?.minDecimals,
     });
-    return formatter.format(value);
+    return formatAmountWithoutRounding(value, formatter, maxDecimals);
   }
 }

--- a/lib/src/lib/components/form-fields/amount-field/amount.pipe.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount.pipe.ts
@@ -1,0 +1,32 @@
+import { Inject, LOCALE_ID, Pipe, PipeTransform } from '@angular/core';
+import { AmountOptions } from './amount-field.model';
+import {
+  LAB900_FORM_MODULE_SETTINGS,
+  Lab900FormModuleSettings,
+} from '../../../models/Lab900FormModuleSettings';
+import { getAmountFormatter } from './amount.helpers';
+
+@Pipe({
+  name: 'amount',
+})
+export class AmountPipe implements PipeTransform {
+  private readonly locale: string;
+
+  public constructor(
+    @Inject(LAB900_FORM_MODULE_SETTINGS)
+    private setting: Lab900FormModuleSettings,
+    @Inject(LOCALE_ID) appLocale: string
+  ) {
+    this.locale = setting?.amountField?.locale ?? appLocale;
+  }
+
+  public transform(value: number, options?: AmountOptions): string {
+    const formatter = getAmountFormatter(this.locale, {
+      maxDecimals:
+        options?.maxDecimals ?? this.setting?.amountField?.maxDecimals,
+      minDecimals:
+        options?.minDecimals ?? this.setting?.amountField?.minDecimals,
+    });
+    return formatter.format(value);
+  }
+}

--- a/lib/src/lib/forms.module.ts
+++ b/lib/src/lib/forms.module.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular-material-components/datetime-picker';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
-import { ModuleWithProviders, NgModule, Type } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
@@ -81,6 +81,8 @@ import {
 } from './models/Lab900FormModuleSettings';
 import { Lab900FormBuilderService } from './services/form-builder.service';
 import { PasswordFieldComponent } from './components/form-fields/password-field/password-field.component';
+import { AmountFieldComponent } from './components/form-fields/amount-field/amount-field.component';
+import { AmountInputDirective } from './components/form-fields/amount-field/amount-input.directive';
 
 const customFields = [
   UnknownFieldComponent,
@@ -127,6 +129,8 @@ const customFields = [
     MultiLangInputFieldComponent,
     LanguagePickerComponent,
     MultiLangFieldControlComponent,
+    AmountFieldComponent,
+    AmountInputDirective,
   ],
   imports: [
     CommonModule,
@@ -168,6 +172,7 @@ const customFields = [
     AuthImageDirective,
     AutofocusDirective,
     SelectFieldComponent,
+    AmountInputDirective,
   ],
 })
 export class Lab900FormsModule {
@@ -182,6 +187,10 @@ export class Lab900FormsModule {
       fieldMask: {
         ...defaultFormModuleSettings.fieldMask,
         ...(settings?.fieldMask ?? {}),
+      },
+      amountField: {
+        ...defaultFormModuleSettings.amountField,
+        ...(settings?.amountField ?? {}),
       },
     };
     return {
@@ -225,6 +234,7 @@ export class Lab900FormsModule {
             DateRangeFieldComponent,
             DateTimeFieldComponent,
             MultiLangInputFieldComponent,
+            AmountFieldComponent,
           },
         },
       ],

--- a/lib/src/lib/forms.module.ts
+++ b/lib/src/lib/forms.module.ts
@@ -83,6 +83,7 @@ import { Lab900FormBuilderService } from './services/form-builder.service';
 import { PasswordFieldComponent } from './components/form-fields/password-field/password-field.component';
 import { AmountFieldComponent } from './components/form-fields/amount-field/amount-field.component';
 import { AmountInputDirective } from './components/form-fields/amount-field/amount-input.directive';
+import { AmountPipe } from './components/form-fields/amount-field/amount.pipe';
 
 const customFields = [
   UnknownFieldComponent,
@@ -131,6 +132,7 @@ const customFields = [
     MultiLangFieldControlComponent,
     AmountFieldComponent,
     AmountInputDirective,
+    AmountPipe,
   ],
   imports: [
     CommonModule,
@@ -173,6 +175,7 @@ const customFields = [
     AutofocusDirective,
     SelectFieldComponent,
     AmountInputDirective,
+    AmountPipe,
   ],
 })
 export class Lab900FormsModule {

--- a/lib/src/lib/models/Lab900FormModuleSettings.ts
+++ b/lib/src/lib/models/Lab900FormModuleSettings.ts
@@ -12,9 +12,16 @@ export interface Lab900FormFieldOptions extends MatFormFieldDefaultOptions {
   showLengthIndicator?: boolean;
 }
 
+export interface Lab900AmountFieldOptions {
+  minDecimals?: number;
+  maxDecimals?: number;
+  locale?: string;
+}
+
 export interface Lab900FormModuleSettings {
   formField?: Lab900FormFieldOptions;
   fieldMask?: Partial<IConfig>;
+  amountField?: Lab900AmountFieldOptions;
 }
 
 export const defaultFormModuleSettings: Lab900FormModuleSettings = {
@@ -27,5 +34,9 @@ export const defaultFormModuleSettings: Lab900FormModuleSettings = {
   fieldMask: {
     thousandSeparator: '.',
     decimalMarker: ',',
+  },
+  amountField: {
+    minDecimals: 0,
+    maxDecimals: 2,
   },
 };

--- a/lib/src/lib/models/editType.ts
+++ b/lib/src/lib/models/editType.ts
@@ -35,4 +35,5 @@ export enum EditType {
   DateRange = 'DateRange',
   DateTime = 'DateTime',
   MultiLangInput = 'MultiLangInput',
+  Amount = 'Amount',
 }

--- a/lib/src/lib/models/lab900-form-field.type.ts
+++ b/lib/src/lib/models/lab900-form-field.type.ts
@@ -22,6 +22,7 @@ import { FormRow } from '../components/form-row/form-row.model';
 import { FormFieldDragNDropFilePreview } from '../components/form-fields/drag-n-drop-file-field/drag-n-drop-file-field.model';
 import { FormFieldPassword } from '../components/form-fields/password-field/password-field.model';
 import { FormFieldDateYearMonthPicker } from '../components/form-fields/date-year-month-field/date-year-month-field.model';
+import { FormFieldAmount } from '../components/form-fields/amount-field/amount-field.model';
 
 export type Lab900FormField<R = any, T extends string | number = string> =
   | FormFieldInput<T>
@@ -47,4 +48,5 @@ export type Lab900FormField<R = any, T extends string | number = string> =
   | FormFieldAutocomplete<R, T>
   | FormFieldAutocompleteMulti<R, T>
   | FormFieldRepeater<T>
-  | FormFieldTextarea<T>;
+  | FormFieldTextarea<T>
+  | FormFieldAmount<T>;

--- a/lib/src/lib/services/form-field-mapping.service.ts
+++ b/lib/src/lib/services/form-field-mapping.service.ts
@@ -31,6 +31,7 @@ export class FormFieldMappingService {
   private readonly multiLangInputFieldComponent: Type<FormComponent>;
   private readonly dragNDropFileFieldComponent: Type<FormComponent>;
   private readonly unknownFieldComponent: Type<FormComponent>;
+  private readonly amountFieldComponent: Type<FormComponent>;
 
   public constructor(@Inject(LAB900_FORM_FIELD_TYPES) lab900FormFieldTypes) {
     this.inputFieldComponent = lab900FormFieldTypes.InputFieldComponent;
@@ -68,6 +69,7 @@ export class FormFieldMappingService {
     this.dragNDropFileFieldComponent =
       lab900FormFieldTypes.DragNDropFileFieldComponent;
     this.unknownFieldComponent = lab900FormFieldTypes.UnknownFieldComponent;
+    this.amountFieldComponent = lab900FormFieldTypes.AmountFieldComponent;
   }
 
   public mapToComponent = (field: Lab900FormField): Type<FormComponent> => {
@@ -120,6 +122,8 @@ export class FormFieldMappingService {
         return this.multiLangInputFieldComponent;
       case EditType.DragNDrop:
         return this.dragNDropFileFieldComponent;
+      case EditType.Amount:
+        return this.amountFieldComponent;
       default:
         return this.unknownFieldComponent;
     }

--- a/lib/src/public-api.ts
+++ b/lib/src/public-api.ts
@@ -13,6 +13,8 @@ export * from './lib/utils/form-field.utils';
 
 export * from './lib/components/form-fields/select-field/field-select.model';
 export * from './lib/components/form-fields/select-field/select-field.component';
+export * from './lib/components/form-fields/amount-field/amount-input.directive';
+export * from './lib/components/form-fields/amount-field/amount.helpers';
 
 export * from './lib/components/form-container/form-container.component';
 

--- a/lib/src/public-api.ts
+++ b/lib/src/public-api.ts
@@ -15,6 +15,7 @@ export * from './lib/components/form-fields/select-field/field-select.model';
 export * from './lib/components/form-fields/select-field/select-field.component';
 export * from './lib/components/form-fields/amount-field/amount-input.directive';
 export * from './lib/components/form-fields/amount-field/amount.helpers';
+export * from './lib/components/form-fields/amount-field/amount.pipe';
 
 export * from './lib/components/form-container/form-container.component';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22568,7 +22568,8 @@
       "version": "12.2.14",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-12.2.14.tgz",
       "integrity": "sha512-dla6JgLWKAo7k4K3O+ouo104wO3BFs+MIOCXoGF4Lp/1pKPSt0orYmvZFBkDZPmyBFYRw9wpL2WHnAAyip40Cw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@ngx-translate/core": {
       "version": "13.0.0",
@@ -23375,7 +23376,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "adjust-sourcemap-loader": {
       "version": "4.0.0",
@@ -23439,7 +23441,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-formats": {
       "version": "2.1.0",
@@ -23454,7 +23457,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -24240,7 +24244,8 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
       "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "class-utils": {
       "version": "0.3.6",
@@ -25380,7 +25385,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
       "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -26353,7 +26359,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-prettier": {
       "version": "3.4.1",
@@ -27966,7 +27973,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -28993,7 +29001,8 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-1.7.0.tgz",
       "integrity": "sha512-pzum1TL7j90DTE86eFt48/s12hqwQuiD+e5aXx2Dc9wDEn2LfGq6RoAxEZZjFiN0RDSCOnosEKRZWxbQ+iMpQQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-source-map-support": {
       "version": "1.4.0",
@@ -31390,25 +31399,29 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
       "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
       "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
       "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
       "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-double-position-gradients": {
       "version": "1.0.0",
@@ -31868,7 +31881,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -31936,7 +31950,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
       "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -33193,7 +33208,8 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/rxjs-for-await/-/rxjs-for-await-0.0.2.tgz",
       "integrity": "sha512-IJ8R/ZCFMHOcDIqoABs82jal00VrZx8Xkgfe7TOKoaRPAW5nH/VFlG23bXpeGdrmtqI9UobFPgUKgCuFc7Lncw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -34253,7 +34269,8 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.2.1.tgz",
       "integrity": "sha512-1k9ZosJCRFaRbY6hH49JFlRB0fVSbmnyq1iTPjNxUmGVjBNEmwrrHPenhlp+Lgo51BojHSf6pl2FcqYaN3PfVg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.0.1",
@@ -35094,7 +35111,8 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
           "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ajv": {
           "version": "6.12.6",
@@ -35964,7 +35982,8 @@
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
       "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml2js": {
       "version": "0.4.23",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -35,6 +35,9 @@ export function TranslationLoaderFactory(
       formField: {
         appearance: 'fill',
       },
+      amountField: {
+        locale: 'de-DE',
+      },
     }),
     TranslateModule.forRoot({
       loader: {

--- a/src/app/modules/showcase-forms/examples/form-field-amount-example/form-field-amount-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-amount-example/form-field-amount-example.component.ts
@@ -3,15 +3,29 @@ import { Lab900FormConfig, EditType } from '@lab900/forms';
 
 @Component({
   selector: 'lab900-form-field-amount-example',
-  template: '<lab900-form [schema]="formSchema"></lab900-form>',
+  template: `<div>
+    <h3>Form field:</h3>
+    <lab900-form [schema]="formSchema"></lab900-form>
+    <h3>Pipe:</h3>
+    <p>
+      The same formatting is also available as a pipe:
+      <code>{{ snippet }}</code>
+    </p>
+    <p>Will result in: {{ 204500.456 | amount }}</p>
+  </div>`,
 })
 export class FormFieldAmountExampleComponent {
+  public readonly snippet = '{{ 204500.456 | amount }}';
   public formSchema: Lab900FormConfig = {
     fields: [
       {
         attribute: 'amount',
         title: 'My amount',
         editType: EditType.Amount,
+        options: {
+          minDecimals: 2,
+          suffix: 'EUR',
+        },
       },
     ],
   };

--- a/src/app/modules/showcase-forms/examples/form-field-amount-example/form-field-amount-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-amount-example/form-field-amount-example.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { Lab900FormConfig, EditType } from '@lab900/forms';
+
+@Component({
+  selector: 'lab900-form-field-amount-example',
+  template: '<lab900-form [schema]="formSchema"></lab900-form>',
+})
+export class FormFieldAmountExampleComponent {
+  public formSchema: Lab900FormConfig = {
+    fields: [
+      {
+        attribute: 'amount',
+        title: 'My amount',
+        editType: EditType.Amount,
+      },
+    ],
+  };
+}

--- a/src/app/modules/showcase-forms/showcase-forms-routing.module.ts
+++ b/src/app/modules/showcase-forms/showcase-forms-routing.module.ts
@@ -35,6 +35,7 @@ import { FormFieldSlideToggleExampleComponent } from './examples/form-field-slid
 import { FormFieldTextareaExampleComponent } from './examples/form-field-textarea-example/form-field-textarea-example.component';
 import { showcaseFormsConfig } from './showcase-forms.constants';
 import { showcaseFormsNavItems } from './showcase-forms.nav-items';
+import { FormFieldAmountExampleComponent } from './examples/form-field-amount-example/form-field-amount-example.component';
 
 const routes: Routes = [
   {
@@ -170,6 +171,12 @@ const routes: Routes = [
     new ShowcaseExample(
       FormFieldNestedGroupsByAttributeExampleComponent,
       'Nested groups by attributes'
+    ),
+  ]),
+  new ShowcaseRoute('form-field-amount', 'Form Fields: Amount', [
+    new ShowcaseExample(
+      FormFieldAmountExampleComponent,
+      'Formatted amount field'
     ),
   ]),
 ];

--- a/src/app/modules/showcase-forms/showcase-forms.module.ts
+++ b/src/app/modules/showcase-forms/showcase-forms.module.ts
@@ -31,6 +31,7 @@ import { FormFieldSelectExampleComponent } from './examples/form-field-select-ex
 import { FormFieldSlideToggleExampleComponent } from './examples/form-field-slide-toggle-example/form-field-slide-toggle-example.component';
 import { FormFieldTextareaExampleComponent } from './examples/form-field-textarea-example/form-field-textarea-example.component';
 import { ShowcaseFormsRoutingModule } from './showcase-forms-routing.module';
+import { FormFieldAmountExampleComponent } from './examples/form-field-amount-example/form-field-amount-example.component';
 
 const examples = [
   FormFieldRepeaterExampleComponent,
@@ -62,6 +63,7 @@ const examples = [
   FormFieldSelectAdvancedExampleComponent,
   FormFieldNestedGroupsExampleComponent,
   FormFieldNestedGroupsByAttributeExampleComponent,
+  FormFieldAmountExampleComponent,
 ];
 
 @NgModule({

--- a/src/app/modules/showcase-forms/showcase-forms.nav-items.ts
+++ b/src/app/modules/showcase-forms/showcase-forms.nav-items.ts
@@ -26,6 +26,10 @@ export const showcaseFormsNavItems: NavItemGroup[] = [
         label: 'forms.form-fields',
         children: [
           {
+            label: 'Amount',
+            route: 'form-field-amount',
+          },
+          {
             label: 'Autocomplete',
             route: 'form-field-autocomplete',
           },


### PR DESCRIPTION
## New field: Amount
Build for STIP but useful for other projects.

### Purpose
A flexible input field where both points & comma's can be used as separators in focus/edit mode. On blur, the inputs will be formatted to a formatted string. 

The fields mask options for the input field were not flexible enough in terms of separators. 

### Approach
_See example in showcase for more details_
#### A new form field `EditType.Amount`.
Options can be set by default in the forRoot of the formModule but can also be overwritten per field in the field configs.
**Important:** the locale can be overwritten in the forRoot because in STIP they want the german locale way of number formatting to always be applied.
#### A new pipe `amount`.
A pipe that can be used to format numbers in the template with same settings as the input field.

### Screenshots
On focus:
![Schermafbeelding 2022-05-19 om 11 30 32](https://user-images.githubusercontent.com/13655941/169261787-01f02a1d-21e4-47f3-bdf8-b85bc68cadb1.png)

On blur:
![Schermafbeelding 2022-05-19 om 11 30 37](https://user-images.githubusercontent.com/13655941/169261819-21a5f0fd-bd15-4a49-acd8-c732dd6b6b18.png)

