### PR TITLE
Fix markdown package error.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@kolkov/angular-editor": "^3.0.0-beta.0 ",
         "@lab900/ui": "^17.0.0",
         "@ngx-translate/core": "^15.0.0",
-        "ngx-markdown": "^17.2.0",
+        "ngx-markdown": "^17.2.1",
         "ngx-mask": "^17.0.7",
         "ngx-mat-select-search": "7.0.6",
         "prismjs": "^1.29.0",
@@ -14428,9 +14428,9 @@
       "dev": true
     },
     "node_modules/ngx-markdown": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-17.2.0.tgz",
-      "integrity": "sha512-Hix8M/RgbtbDrCTKCsxRJuYXzBBNxFHkM7fd2zGypS7CmhhjAWueEWtUDwaetEHYGGeXvzXhpCml4TUAAMua+w==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-17.2.1.tgz",
+      "integrity": "sha512-TKzxP2R2uTGpVFx0OZDFC/BpNJYUabG2z59/9/PXrTP3R7xTNFuvGQZSNitAQFD7nI3Uko87Ra3GJrbaHdjeBA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -29545,9 +29545,9 @@
       }
     },
     "ngx-markdown": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-17.2.0.tgz",
-      "integrity": "sha512-Hix8M/RgbtbDrCTKCsxRJuYXzBBNxFHkM7fd2zGypS7CmhhjAWueEWtUDwaetEHYGGeXvzXhpCml4TUAAMua+w==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-17.2.1.tgz",
+      "integrity": "sha512-TKzxP2R2uTGpVFx0OZDFC/BpNJYUabG2z59/9/PXrTP3R7xTNFuvGQZSNitAQFD7nI3Uko87Ra3GJrbaHdjeBA==",
       "requires": {
         "clipboard": "^2.0.11",
         "emoji-toolkit": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@kolkov/angular-editor": "^3.0.0-beta.0 ",
     "@lab900/ui": "^17.0.0",
     "@ngx-translate/core": "^15.0.0",
-    "ngx-markdown": "^17.2.0",
+    "ngx-markdown": "^17.2.1",
     "ngx-mask": "^17.0.7",
     "ngx-mat-select-search": "7.0.6",
     "prismjs": "^1.29.0",


### PR DESCRIPTION
The 17.2.0 version contains some issue regarding types not being  available. 

This bump seems to fix the compiling issue.