### PR TITLE
Restructured config to display in tabs.

### DIFF
--- a/src/app/modules/showcase-forms/examples/form-conditionals-example/config/form-conditionals-data.ts
+++ b/src/app/modules/showcase-forms/examples/form-conditionals-example/config/form-conditionals-data.ts
@@ -1,3 +1,0 @@
-export const formConditionalsData = {
-  country: 'BEL',
-};

--- a/src/app/modules/showcase-forms/examples/form-conditionals-example/form-conditionals-example.component.config.ts
+++ b/src/app/modules/showcase-forms/examples/form-conditionals-example/form-conditionals-example.component.config.ts
@@ -1,6 +1,10 @@
 import { EditType, Lab900FormConfig } from '@lab900/forms';
 import { ValueLabel } from '@lab900/forms';
 
+export const formConditionalsData = {
+  country: 'BEL',
+};
+
 export const formConditionalsExample: Lab900FormConfig = {
   fields: [
     {

--- a/src/app/modules/showcase-forms/examples/form-conditionals-example/form-conditionals-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-conditionals-example/form-conditionals-example.component.ts
@@ -1,7 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
 import { Lab900Form, Lab900FormConfig } from '@lab900/forms';
-import { formConditionalsExample } from './config/form-conditionals-example';
-import { formConditionalsData } from './config/form-conditionals-data';
+import { formConditionalsData, formConditionalsExample } from './form-conditionals-example.component.config';
 import { MatButton } from '@angular/material/button';
 
 @Component({

--- a/src/app/modules/showcase-forms/showcase-forms.routes.ts
+++ b/src/app/modules/showcase-forms/showcase-forms.routes.ts
@@ -65,6 +65,8 @@ export default [
     new ShowcaseExample(
       FormConditionalsExampleComponent,
       'Conditional Form Container',
+      null,
+      ['TS', 'config.ts']
     ),
     new ShowcaseExample(
       FormConditionalValidationExampleComponent,


### PR DESCRIPTION

<img width="831" alt="Screenshot 2024-05-13 at 09 24 28" src="https://github.com/lab900/angular-library-forms/assets/169051418/a4dc9f45-204d-41af-bb66-6129e52de2ac">

The obvious red rectangles indicate the current issue, we import the config file in the component. Normally this is expected but currently only the component ts file is shown in the example. To address this incompletion I have moved the config objects outside the config folder into one file named form-conditionals-example.component.**config.ts**

This allows us to add a new tab in the ExampleViewer.

<img width="1095" alt="Screenshot 2024-05-13 at 09 24 15" src="https://github.com/lab900/angular-library-forms/assets/169051418/16a4943e-5381-417d-b9cd-1e09aa1b4f57">
