### PR TITLE
Added condition to check for single tab.

### DIFF
--- a/src/app/modules/shared/components/showcase-page/showcase-page.component.html
+++ b/src/app/modules/shared/components/showcase-page/showcase-page.component.html
@@ -1,6 +1,11 @@
 @if (data && currentTab && navItems?.length) {
   <div class="showcase-page row">
-    <lab900-page-header [pageTitle]="data.title" [navItems]="navItems" [tabPanel]="tabNavPanel" />
+    @if (navItems.length === 1) {
+      <h1>{{data.title}}</h1> 
+    }
+    @else {
+      <lab900-page-header [pageTitle]="data.title" [navItems]="navItems" [tabPanel]="tabNavPanel" />
+    }
     <mat-tab-nav-panel #tabNavPanel>
       @switch (currentTab) {
         @case ("guide") {


### PR DESCRIPTION
<img width="1051" alt="Screenshot 2024-05-13 at 09 42 20" src="https://github.com/lab900/angular-library-forms/assets/169051418/cb5def55-dd11-46e1-8745-8f86b8fc834b">

This TabNav is useless, a condition has been added to only print the header title if only one item is provided. 