### PR TITLE
fix: select issues

### DIFF
--- a/lib/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.html
@@ -8,7 +8,7 @@
     @if (schema?.title) {
       <mat-label>
         @if (loading$.value) {
-          {{ "form.field.loading" | translate }}
+          {{ 'form.field.loading' | translate }}
         }
         @if (schema.title && !loading$.value) {
           {{ schema.title | translate }}
@@ -18,7 +18,9 @@
     <mat-select
       #select
       placeholder="{{ placeholder | translate }}"
-      [compareWith]="options?.compareWith ? options?.compareWith : defaultCompare"
+      [compareWith]="
+        options?.compareWith ? options?.compareWith : defaultCompare
+      "
       [formControlName]="fieldAttribute"
       [multiple]="options?.multiple"
       [required]="fieldIsRequired"
@@ -44,17 +46,32 @@
             [searching]="loading$.value"
             (ngModelChange)="onSearch($event)"
             [ngModelOptions]="{ standalone: true }"
-            [placeholderLabel]="options?.search?.placeholder ?? 'form.field.search' | translate"
-            [disableScrollToActiveOnOptionsChanged]="options?.infiniteScroll?.enabled"
+            [placeholderLabel]="
+              options?.search?.placeholder ?? 'form.field.search' | translate
+            "
+            [disableScrollToActiveOnOptionsChanged]="
+              options?.infiniteScroll?.enabled
+            "
             [clearSearchInput]="options?.search?.clearOnClose ?? false"
           >
             <div class="no-entries-found" ngxMatSelectNoEntriesFound>
               @if (searchQuery$ | async; as searchQuery) {
-                <span>{{ options?.search?.notFoundLabel ?? "form.field.no_options_found" | translate: { searchQuery: searchQuery } }}</span>
+                <span>{{
+                  options?.search?.notFoundLabel ??
+                    'form.field.no_options_found'
+                    | translate: { searchQuery: searchQuery }
+                }}</span>
                 @if (options?.search?.addNewFn) {
-                  <button mat-button [color]="options?.search?.addNewBtnColor ?? 'primary'" (click)="handleAddNew(searchQuery)">
+                  <button
+                    mat-button
+                    [color]="options?.search?.addNewBtnColor ?? 'primary'"
+                    (click)="handleAddNew(searchQuery)"
+                  >
                     <mat-icon>add</mat-icon>
-                    <span>{{ options?.search?.addNewLabel ?? "form.field.add_new" | translate: { searchQuery: searchQuery } }}</span>
+                    <span>{{
+                      options?.search?.addNewLabel ?? 'form.field.add_new'
+                        | translate: { searchQuery: searchQuery }
+                    }}</span>
                   </button>
                 }
               }
@@ -62,30 +79,56 @@
           </ngx-mat-select-search>
         </mat-option>
       }
-      @if (options?.multiple && options?.selectAll?.enabled && (selectOptions$$ | async)?.length) {
-        <div class="mat-mdc-option mdc-list-item mat-mdc-option-multiple select-all" (click)="handleToggleAllSelection()">
-          <mat-pseudo-checkbox [state]="selectAllState$ | async" [disabled]="options?.selectAll?.disabled || loading$.value" />
+      @if (
+        options?.multiple &&
+        options?.selectAll?.enabled &&
+        (selectOptions$$ | async)?.length
+      ) {
+        <div
+          class="mat-mdc-option mdc-list-item mat-mdc-option-multiple select-all"
+          (click)="handleToggleAllSelection()"
+        >
+          <mat-pseudo-checkbox
+            [state]="selectAllState$ | async"
+            [disabled]="options?.selectAll?.disabled || loading$.value"
+          />
           <span class="mdc-list-item__primary-text">
-            {{ options.selectAll?.label || "forms.select-field.selectAllLabel" | translate }}
+            {{
+              options.selectAll?.label || 'forms.select-field.selectAllLabel'
+                | translate
+            }}
           </span>
         </div>
       }
       @for (item of selectOptions$$ | async; track item) {
-        <mat-option [value]="item.value" [disabled]="item.disabled || loading$.value">
+        <mat-option
+          [value]="item.value"
+          [disabled]="item.disabled || loading$.value"
+        >
           <div [innerHTML]="item.label | translate"></div>
         </mat-option>
       }
     </mat-select>
     @if (showClearButton(this.fieldControl.value)) {
-      <button matSuffix mat-icon-button type="button" aria-label="Clear" (click)="handleClearFieldButtonClick($event)">
+      <button
+        matSuffix
+        mat-icon-button
+        type="button"
+        aria-label="Clear"
+        (click)="handleClearFieldButtonClick($event)"
+      >
         <mat-icon>close</mat-icon>
       </button>
     }
     @if (hint && !(schema.options.hint.hideHintOnValidValue && select.value)) {
-      <mat-hint><span [innerHTML]="hint | translate: hintValueTranslateData"></span></mat-hint>
+      <mat-hint
+        ><span [innerHTML]="hint | translate: hintValueTranslateData"></span
+      ></mat-hint>
     }
     @if (!valid) {
-      <mat-error><span [innerHTML]="getErrorMessage(this.group) | async"></span></mat-error>
+      <mat-error
+        ><span [innerHTML]="getErrorMessage(this.group) | async"></span
+      ></mat-error>
     }
   </mat-form-field>
 }
@@ -93,14 +136,16 @@
 @if (fieldIsReadonly && !fieldIsHidden) {
   <div class="lab900-readonly-field">
     @if (options?.readonlyLabel || schema.title) {
-      <span class="lab900-readonly-field__label">{{ options?.readonlyLabel || schema.title | translate }}</span>
+      <span class="lab900-readonly-field__label">{{
+        options?.readonlyLabel || schema.title | translate
+      }}</span>
     }
     @if (!loading$.value || !fieldControl.value) {
       <div [innerHTML]="getReadOnlyDisplay()"></div>
     }
     @if (loading$.value && fieldControl.value) {
       <div>
-        {{ "form.field.loading" | translate }}
+        {{ 'form.field.loading' | translate }}
       </div>
     }
   </div>

--- a/lib/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -179,7 +179,10 @@ export class SelectFieldComponent<T>
 
   public ngOnInit(): void {
     // load all options from the start
-    if (!this.options?.fetchOptionsOnFocus) {
+    if (
+      typeof this.options?.selectOptions !== 'function' ||
+      !this.options?.fetchOptionsOnFocus
+    ) {
       this.selectOptionsListener();
     }
 
@@ -459,12 +462,11 @@ export class SelectFieldComponent<T>
    * Add the current form control value to the select options
    */
   private addValueToOptions(options = this.selectOptions): ValueLabel<T>[] {
-    if(!this.options?.infiniteScroll?.enabled && !this.options?.search?.enabled) {
-      return options;
-    }
-
     let label: string;
-    if (!this.options?.displaySelectedOptionFn) {
+    if (
+      typeof this.options?.selectOptions === 'function' &&
+      !this.options?.displaySelectedOptionFn
+    ) {
       label = "ERROR: Can't display";
       console.error(
         `Please define a displaySelectedOptionFn to display your currently selected option for the field with attribute ${this.fieldAttribute} since it is not included in the current options`,
@@ -475,7 +477,7 @@ export class SelectFieldComponent<T>
       .filter((value) => !options?.some((o) => compare(o.value, value)))
       .map((v: T) => ({
         value: v,
-        label: label ?? this.options.displaySelectedOptionFn(v),
+        label: label ?? this.options.displaySelectedOptionFn?.(v),
       }));
 
     if (missingOptions?.length) {


### PR DESCRIPTION
**Some fixes after recent updates:**

1. the `fetchOptionsOnFocus` should only do something if the select options are received via a function. If it's a static options list this isn't useful.  Eg a list of enum options can always be rendered directly. 

2. the new addValueToOptions check broke the select in certain use cases. 

3. **UNRESOLVED** - Bigger issue, we seem to have problems with change detection if form data is fetched async since Angular 17. The field values are only visible after a tick happens. Will try to resolve this ASAP, will check v16.


https://github.com/lab900/angular-library-forms/assets/13655941/959b8c60-25b1-429c-86d4-a881eaf34ecf

