### PR TITLE
feat(CAB-130):[FE] added a optional way to see a color dot at the autocomplete field options

### DIFF
--- a/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
+++ b/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
@@ -26,7 +26,12 @@
     <mat-autocomplete #auto="matAutocomplete" [displayWith]="options.displayInputFn">
       @for (option of filteredOptions | async; track option) {
         <mat-option [value]="option?.value" [disabled]="option?.disabled">
+          <div class="option-container">
             <div [innerHTML]="option.label | translate"></div>
+          @if (option.color) {
+            <span class="color-circle" [style.background-color]="option.color"></span>
+          }
+          </div>
         </mat-option>
       }
     </mat-autocomplete>

--- a/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.scss
+++ b/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.scss
@@ -1,0 +1,13 @@
+.option-container {
+  display: flex;
+  align-items: center;
+}
+.color-circle {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 8px;
+  margin-left: 8px;
+  vertical-align: middle;
+}

--- a/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.scss
+++ b/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.scss
@@ -7,7 +7,7 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  margin-right: 8px;
+  position: absolute;
+  right: 18px;
   margin-left: 8px;
-  vertical-align: middle;
 }

--- a/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.ts
+++ b/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.ts
@@ -25,6 +25,7 @@ import { MatIcon } from '@angular/material/icon';
 @Component({
   selector: 'lab900-autocomplete-field',
   templateUrl: './autocomplete-field.component.html',
+  styleUrls: ['./autocomplete-field.component.scss'],
   standalone: true,
   imports: [
     MatFormFieldModule,

--- a/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
+++ b/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
@@ -35,6 +35,9 @@
       @for (option of filteredOptions | async; track option) {
         <mat-option [value]="option?.value" [disabled]="option?.disabled">
           {{ option.label | translate }}
+          @if (option.color) {
+            <span class="color-circle" [style.background-color]="option.color"></span>
+          }
         </mat-option>
       }
     </mat-autocomplete>

--- a/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.scss
+++ b/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.scss
@@ -1,0 +1,9 @@
+.color-circle {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 8px;
+  margin-left: 8px;
+  vertical-align: middle;
+}

--- a/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.scss
+++ b/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.scss
@@ -3,7 +3,7 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  margin-right: 8px;
+  position: absolute;
+  right: 18px;
   margin-left: 8px;
-  vertical-align: middle;
 }

--- a/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.ts
+++ b/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.ts
@@ -27,6 +27,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 @Component({
   selector: 'lab900-autocomplete-multiple-field',
   templateUrl: './autocomplete-multiple-field.component.html',
+  styleUrls: ['./autocomplete-multiple-field.component.scss'],
+
   standalone: true,
   imports: [
     ReactiveFormsModule,

--- a/lib/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.html
@@ -107,7 +107,7 @@
         >
           <div [innerHTML]="item.label | translate"></div>
           @if (item.color) {
-            <span class="color-circle" [style.background-color]="item.color">pj</span>
+            <span class="color-circle" [style.background-color]="item.color"></span>
           }
         </mat-option>
       }

--- a/lib/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.html
@@ -106,6 +106,9 @@
           [disabled]="item.disabled || loading$.value"
         >
           <div [innerHTML]="item.label | translate"></div>
+          @if (item.color) {
+            <span class="color-circle" [style.background-color]="item.color">pj</span>
+          }
         </mat-option>
       }
     </mat-select>

--- a/lib/src/lib/models/form-field-base.ts
+++ b/lib/src/lib/models/form-field-base.ts
@@ -6,6 +6,7 @@ export interface ValueLabel<T = any> {
   value: T;
   label: string;
   disabled?: boolean;
+  color?: string;
 }
 
 export interface Icon {

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-example.component.ts
@@ -21,8 +21,8 @@ export class FormFieldAutocompleteExampleComponent {
   public formContainer: Lab900Form<any>;
 
   public options: ValueLabel[] = [
-    { name: 'John', color: 'red' },
-    { name: 'Shelley', color: 'green' },
+    { name: 'Mary', color: 'red' },
+    { name: 'Shelley' },
     { name: 'Igor', color: 'blue' },
   ].map((value) => {
     const image =

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-example.component.ts
@@ -21,14 +21,14 @@ export class FormFieldAutocompleteExampleComponent {
   public formContainer: Lab900Form<any>;
 
   public options: ValueLabel[] = [
-    { name: 'Mary' },
-    { name: 'Shelley' },
-    { name: 'Igor' },
+    { name: 'John', color: 'red' },
+    { name: 'Shelley', color: 'green' },
+    { name: 'Igor', color: 'blue' },
   ].map((value) => {
     const image =
       'https://firebasestorage.googleapis.com/v0/b/lab900-website-production.appspot.com/o/public%2Fproject-images%2Fyou%2Fyou-mockup.svg?alt=media';
-    const label = `<div class="user-option"><img width="20" height="20" src="${image}"> ${value.name}</div>`;
-    return { value, label };
+    const label = `<div class="user-option"><img width="20" height="20" src="${image}"> ${value.name} <span class="color-circle" style="background-color:${value.color}"></span></div>`;
+    return { value, label, color: value.color };
   });
 
   public formSchema: Lab900FormConfig = {

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
@@ -30,7 +30,7 @@ export class FormFieldAutocompleteMultipleExampleComponent {
         editType: EditType.AutocompleteMultiple,
         options: {
           autocompleteOptions: (value: string) => of(this.filter(value)),
-          displayInputFn: (user: { name: string; color: string }) => user?.name,
+          displayInputFn: (user: { name: string }) => user?.name,
         },
       },
     ],

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
@@ -17,10 +17,10 @@ import { JsonPipe } from '@angular/common';
 })
 export class FormFieldAutocompleteMultipleExampleComponent {
   public options: ValueLabel[] = [
-    { name: 'Mary' },
+    { name: 'casy', label: 'Mary', color: 'red' },
     { name: 'Shelley' },
-    { name: 'Igor' },
-  ].map((value) => ({ value, label: value.name }));
+    { name: 'Igor', color: 'blue' },
+  ].map((value) => ({ value, label: value.name, color: value.color }));
 
   public formSchema: Lab900FormConfig = {
     fields: [
@@ -30,7 +30,8 @@ export class FormFieldAutocompleteMultipleExampleComponent {
         editType: EditType.AutocompleteMultiple,
         options: {
           autocompleteOptions: (value: string) => of(this.filter(value)),
-          displayInputFn: (user: { name: string }) => user?.name,
+          displayInputFn: (user: { name: string; color: string }) =>
+            `${user?.name}`,
         },
       },
     ],

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
@@ -17,7 +17,7 @@ import { JsonPipe } from '@angular/common';
 })
 export class FormFieldAutocompleteMultipleExampleComponent {
   public options: ValueLabel[] = [
-    { name: 'casy', label: 'Mary', color: 'red' },
+    { name: 'Mary', color: 'red' },
     { name: 'Shelley' },
     { name: 'Igor', color: 'blue' },
   ].map((value) => ({ value, label: value.name, color: value.color }));

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
@@ -30,8 +30,7 @@ export class FormFieldAutocompleteMultipleExampleComponent {
         editType: EditType.AutocompleteMultiple,
         options: {
           autocompleteOptions: (value: string) => of(this.filter(value)),
-          displayInputFn: (user: { name: string; color: string }) =>
-            `${user?.name}`,
+          displayInputFn: (user: { name: string; color: string }) => user?.name,
         },
       },
     ],


### PR DESCRIPTION
Adjusted autocomplete-field and autocomplete-multiple-field to have a way to show colored circle next to the options (needed for story cab-130 FE - status color in filter options & chips (https://sea-tank.atlassian.net/browse/CAB-130)
Also adjusted  the autocomplete-field examples to see if change works.

screenshots:
before:
![Screenshot 2024-08-08 at 15 33 30](https://github.com/user-attachments/assets/2a34586a-8e8e-41b1-927a-cb40c2109c3a)
After:
![Screenshot 2024-08-08 at 15 33 24](https://github.com/user-attachments/assets/6703cd58-541b-4d38-b5ed-04536e135a7a)
after comment
![Screenshot 2024-08-08 at 16 21 51](https://github.com/user-attachments/assets/3357cea1-5f5b-4b81-935d-bb623c0ff782)
![Screenshot 2024-08-08 at 16 21 55](https://github.com/user-attachments/assets/a6dff1b3-87b0-406e-b553-146caf63a475)


