### PR TITLE
Feat/adding ids  for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 18.2.0
+
+- Adding possibility for the usage of custom Id's to form: columns, rows, fields and buttons.
+
 ## 18.1.1/18.1.2
 
 - fixes for displaying error messages

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "18.1.3",
+  "version": "18.2.0",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "license": "MIT",
   "peerDependencies": {

--- a/lib/src/lib/components/AbstractFormComponent.ts
+++ b/lib/src/lib/components/AbstractFormComponent.ts
@@ -48,7 +48,16 @@ export abstract class FormComponent<S extends Lab900FormField = Lab900FormField>
   public readonly readonlyLabel = computed<string | undefined>(
     () => this._schema().options?.readonlyLabel ?? this.label(),
   );
-
+  public get elementId(): string {
+    const customId = this._options()?.customId;
+    const fieldAttribute = this.fieldAttribute;
+    if (customId) {
+      return `${customId}`;
+    } else if (fieldAttribute) {
+      return `${fieldAttribute}`;
+    }
+    return '';
+  }
   public readonly errorMessage = toSignal<string>(
     toObservable(this._fieldControl).pipe(
       filter((field) => !!field),

--- a/lib/src/lib/components/AbstractFormComponent.ts
+++ b/lib/src/lib/components/AbstractFormComponent.ts
@@ -48,7 +48,8 @@ export abstract class FormComponent<S extends Lab900FormField = Lab900FormField>
   public readonly readonlyLabel = computed<string | undefined>(
     () => this._schema().options?.readonlyLabel ?? this.label(),
   );
-  public get elementId(): string {
+
+  public readonly elementId = computed<string>(() => {
     const customId = this._options()?.customId;
     const fieldAttribute = this.fieldAttribute;
     if (customId) {
@@ -57,7 +58,8 @@ export abstract class FormComponent<S extends Lab900FormField = Lab900FormField>
       return `${fieldAttribute}`;
     }
     return '';
-  }
+  });
+
   public readonly errorMessage = toSignal<string>(
     toObservable(this._fieldControl).pipe(
       filter((field) => !!field),

--- a/lib/src/lib/components/AbstractFormComponent.ts
+++ b/lib/src/lib/components/AbstractFormComponent.ts
@@ -50,10 +50,10 @@ export abstract class FormComponent<S extends Lab900FormField = Lab900FormField>
   );
 
   public readonly elementId = computed<string>(() => {
-    const customId = this._options()?.customId;
+    const elementId = this._options()?.elementId;
     const fieldAttribute = this.fieldAttribute;
-    if (customId) {
-      return `${customId}`;
+    if (elementId) {
+      return `${elementId}`;
     } else if (fieldAttribute) {
       return `${fieldAttribute}`;
     }

--- a/lib/src/lib/components/AbstractFormComponent.ts
+++ b/lib/src/lib/components/AbstractFormComponent.ts
@@ -57,7 +57,7 @@ export abstract class FormComponent<S extends Lab900FormField = Lab900FormField>
     } else if (fieldAttribute) {
       return `${fieldAttribute}`;
     }
-    return '';
+    return `random-${Math.random().toString(36)}`;
   });
 
   public readonly errorMessage = toSignal<string>(

--- a/lib/src/lib/components/form-column/form-column.component.html
+++ b/lib/src/lib/components/form-column/form-column.component.html
@@ -1,11 +1,11 @@
 @if (visible() && _schema()) {
-  <div [hidden]="isHidden(schema)" class="lab900-form-column {{ _options()?.customClass }}">
+  <div [hidden]="isHidden(schema)" class="lab900-form-column {{ _options()?.customClass }}"  id="lab900-form-column-{{elementId}}">
     @if ((fieldIsReadonly && _options()?.readonlyLabel) || label()) {
       <span class="lab900-form-field-label lab900-form-column-label {{ _options()?.customTitleClass }}">{{
         (!fieldIsReadonly ? label() : _options()?.readonlyLabel || label()) | translate
       }}</span>
     }
-    <div class="form-column" [class.mobile-cols]="_options()?.mobileCols">
+    <div class="form-column" [class.mobile-cols]="_options()?.mobileCols" id="form-column-{{elementId}}">
       @for (field of nestedFields(); track field) {
         <div
           [class.hidden]="isHidden(field)"

--- a/lib/src/lib/components/form-column/form-column.component.html
+++ b/lib/src/lib/components/form-column/form-column.component.html
@@ -1,5 +1,5 @@
 @if (visible() && _schema()) {
-  <div [hidden]="isHidden(schema)" class="lab900-form-column {{ _options()?.customClass }}"  id="lab900-form-column-{{this.elementId()}}">
+  <div [hidden]="isHidden(schema)" class="lab900-form-column {{ _options()?.customClass }}"  id="lab900-form-column-{{elementId()}}">
     @if ((fieldIsReadonly && _options()?.readonlyLabel) || label()) {
       <span class="lab900-form-field-label lab900-form-column-label {{ _options()?.customTitleClass }}">{{
         (!fieldIsReadonly ? label() : _options()?.readonlyLabel || label()) | translate

--- a/lib/src/lib/components/form-column/form-column.component.html
+++ b/lib/src/lib/components/form-column/form-column.component.html
@@ -1,5 +1,5 @@
 @if (visible() && _schema()) {
-  <div [hidden]="isHidden(schema)" class="lab900-form-column {{ _options()?.customClass }}"  id="lab900-form-column-{{elementId}}">
+  <div [hidden]="isHidden(schema)" class="lab900-form-column {{ _options()?.customClass }}"  id="lab900-form-column-{{this.elementId()}}">
     @if ((fieldIsReadonly && _options()?.readonlyLabel) || label()) {
       <span class="lab900-form-field-label lab900-form-column-label {{ _options()?.customTitleClass }}">{{
         (!fieldIsReadonly ? label() : _options()?.readonlyLabel || label()) | translate

--- a/lib/src/lib/components/form-container/form-container.component.html
+++ b/lib/src/lib/components/form-container/form-container.component.html
@@ -3,6 +3,7 @@
     [formGroup]="_form()"
     class="lab900-form"
     [autocomplete]="setting?.disableBrowserAutocomplete ? 'off' : 'on'"
+    id="lab900-form-{{customId()}}"
   >
     <div class="lab900-form__inner">
       @for (field of fields(); track field) {

--- a/lib/src/lib/components/form-container/form-container.component.html
+++ b/lib/src/lib/components/form-container/form-container.component.html
@@ -3,7 +3,7 @@
     [formGroup]="_form()"
     class="lab900-form"
     [autocomplete]="setting?.disableBrowserAutocomplete ? 'off' : 'on'"
-    id="lab900-form-{{customId()}}"
+    id="lab900-form-{{formId()}}"
   >
     <div class="lab900-form__inner">
       @for (field of fields(); track field) {

--- a/lib/src/lib/components/form-container/form-container.component.ts
+++ b/lib/src/lib/components/form-container/form-container.component.ts
@@ -47,7 +47,7 @@ export class Lab900Form<T> {
   });
   public readonly controls = computed(() => this._form().controls);
   public readonly readonly = computed(() => this.schema()?.readonly);
-  public readonly customId = computed(() => this.schema()?.customId);
+  public readonly formId = computed(() => this.schema()?.formId);
 
   public get form(): UntypedFormGroup {
     return this._form();

--- a/lib/src/lib/components/form-container/form-container.component.ts
+++ b/lib/src/lib/components/form-container/form-container.component.ts
@@ -47,6 +47,7 @@ export class Lab900Form<T> {
   });
   public readonly controls = computed(() => this._form().controls);
   public readonly readonly = computed(() => this.schema()?.readonly);
+  public readonly customId = computed(() => this.schema()?.customId);
 
   public get form(): UntypedFormGroup {
     return this._form();

--- a/lib/src/lib/components/form-fields/amount-field/amount-field.component.html
+++ b/lib/src/lib/components/form-fields/amount-field/amount-field.component.html
@@ -3,7 +3,7 @@
     [formGroup]="group"
     class="lab900-input-field {{ options?.align || 'left' }}"
     [class.spanFix]="options?.suffix || options?.prefix"
-    id="lab900-input-field-{{ this.elementId()}}"
+    id="lab900-input-field-{{ elementId()}}"
   >
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/amount-field/amount-field.component.html
+++ b/lib/src/lib/components/form-fields/amount-field/amount-field.component.html
@@ -3,7 +3,7 @@
     [formGroup]="group"
     class="lab900-input-field {{ options?.align || 'left' }}"
     [class.spanFix]="options?.suffix || options?.prefix"
-    id="lab900-input-field-{{ fieldAttribute }}"
+    id="lab900-input-field-{{ elementId }}"
   >
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/amount-field/amount-field.component.html
+++ b/lib/src/lib/components/form-fields/amount-field/amount-field.component.html
@@ -3,7 +3,7 @@
     [formGroup]="group"
     class="lab900-input-field {{ options?.align || 'left' }}"
     [class.spanFix]="options?.suffix || options?.prefix"
-    id="lab900-input-field-{{ elementId }}"
+    id="lab900-input-field-{{ this.elementId()}}"
   >
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/amount-field/amount-field.component.ts
+++ b/lib/src/lib/components/form-fields/amount-field/amount-field.component.ts
@@ -2,7 +2,6 @@ import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../AbstractFormComponent';
 import { FormFieldAmount } from './amount-field.model';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { AsyncPipe, NgClass } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatInputModule } from '@angular/material/input';
@@ -20,11 +19,9 @@ import { IconComponent } from '@lab900/ui';
     MatInputModule,
     ReactiveFormsModule,
     TranslateModule,
-    NgClass,
     AutofocusDirective,
     AmountInputDirective,
     IconComponent,
-    AsyncPipe,
   ],
 })
 export class AmountFieldComponent extends FormComponent<FormFieldAmount> {

--- a/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
+++ b/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-autocomplete-field" id="lab900-autocomplete-field-{{ elementId }}">
+  <mat-form-field [formGroup]="group" class="lab900-autocomplete-field" id="lab900-autocomplete-field-{{ this.elementId() }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
+++ b/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-autocomplete-field" id="lab900-autocomplete-field-{{ fieldAttribute }}">
+  <mat-form-field [formGroup]="group" class="lab900-autocomplete-field" id="lab900-autocomplete-field-{{ elementId }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
+++ b/lib/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-autocomplete-field" id="lab900-autocomplete-field-{{ this.elementId() }}">
+  <mat-form-field [formGroup]="group" class="lab900-autocomplete-field" id="lab900-autocomplete-field-{{ elementId() }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
+++ b/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
@@ -2,7 +2,7 @@
   <mat-form-field
     [formGroup]="group"
     class="lab900-autocomplete-multi-field"
-    id="lab900-autocomplete-multi-field-{{ fieldAttribute }}"
+    id="lab900-autocomplete-multi-field-{{ elementId }}"
   >
     @if (label()) {
       <mat-label translate>{{ label() }}</mat-label>

--- a/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
+++ b/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
@@ -2,7 +2,7 @@
   <mat-form-field
     [formGroup]="group"
     class="lab900-autocomplete-multi-field"
-    id="lab900-autocomplete-multi-field-{{ this.elementId() }}"
+    id="lab900-autocomplete-multi-field-{{ elementId() }}"
   >
     @if (label()) {
       <mat-label translate>{{ label() }}</mat-label>

--- a/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
+++ b/lib/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
@@ -2,7 +2,7 @@
   <mat-form-field
     [formGroup]="group"
     class="lab900-autocomplete-multi-field"
-    id="lab900-autocomplete-multi-field-{{ elementId }}"
+    id="lab900-autocomplete-multi-field-{{ this.elementId() }}"
   >
     @if (label()) {
       <mat-label translate>{{ label() }}</mat-label>

--- a/lib/src/lib/components/form-fields/button-field/button-field.component.html
+++ b/lib/src/lib/components/form-fields/button-field/button-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-button-field button-field mat-form-field-wrapper"
-    id="lab900-button-field-{{elementId}}"
+    id="lab900-button-field-{{this.elementId()}}"
   >
     @if (label(); as label) {
       <div class="lab900-button-field__label">

--- a/lib/src/lib/components/form-fields/button-field/button-field.component.html
+++ b/lib/src/lib/components/form-fields/button-field/button-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-button-field button-field mat-form-field-wrapper"
-    id="lab900-button-field-{{ fieldAttribute }}"
+    id="lab900-button-field-{{elementId}}"
   >
     @if (label(); as label) {
       <div class="lab900-button-field__label">

--- a/lib/src/lib/components/form-fields/button-field/button-field.component.html
+++ b/lib/src/lib/components/form-fields/button-field/button-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-button-field button-field mat-form-field-wrapper"
-    id="lab900-button-field-{{this.elementId()}}"
+    id="lab900-button-field-{{elementId()}}"
   >
     @if (label(); as label) {
       <div class="lab900-button-field__label">

--- a/lib/src/lib/components/form-fields/button-field/button-field.component.html
+++ b/lib/src/lib/components/form-fields/button-field/button-field.component.html
@@ -22,6 +22,7 @@
       [suffixIcon]="options.suffixIcon"
       [svgIcon]="options.svgIcon"
       [containerClass]="options.containerClass"
+      [buttonId]="options.buttonId"
     />
   </div>
 }

--- a/lib/src/lib/components/form-fields/button-field/button-field.component.ts
+++ b/lib/src/lib/components/form-fields/button-field/button-field.component.ts
@@ -3,7 +3,7 @@ import { FormComponent } from '../../AbstractFormComponent';
 import { FormFieldButton } from './button-field.model';
 import { Lab900ButtonComponent } from '@lab900/ui';
 import { MatTooltip } from '@angular/material/tooltip';
-import { MatLabel } from '@angular/material/form-field';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
 
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -12,7 +12,7 @@ import { TranslateModule } from '@ngx-translate/core';
   selector: 'lab900-button-field',
   templateUrl: './button-field.component.html',
   standalone: true,
-  imports: [MatTooltip, MatLabel, ReactiveFormsModule, TranslateModule, Lab900ButtonComponent],
+  imports: [MatTooltip, MatLabel, ReactiveFormsModule, TranslateModule, Lab900ButtonComponent, MatFormField]
 })
 export class ButtonFieldComponent extends FormComponent<FormFieldButton> {
   @HostBinding('class')

--- a/lib/src/lib/components/form-fields/button-field/button-field.component.ts
+++ b/lib/src/lib/components/form-fields/button-field/button-field.component.ts
@@ -3,16 +3,16 @@ import { FormComponent } from '../../AbstractFormComponent';
 import { FormFieldButton } from './button-field.model';
 import { Lab900ButtonComponent } from '@lab900/ui';
 import { MatTooltip } from '@angular/material/tooltip';
-import { MatFormField, MatLabel } from '@angular/material/form-field';
 
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
+import { MatLabel } from '@angular/material/form-field';
 
 @Component({
   selector: 'lab900-button-field',
   templateUrl: './button-field.component.html',
   standalone: true,
-  imports: [MatTooltip, MatLabel, ReactiveFormsModule, TranslateModule, Lab900ButtonComponent]
+  imports: [MatTooltip, ReactiveFormsModule, TranslateModule, Lab900ButtonComponent, MatLabel]
 })
 export class ButtonFieldComponent extends FormComponent<FormFieldButton> {
   @HostBinding('class')

--- a/lib/src/lib/components/form-fields/button-field/button-field.component.ts
+++ b/lib/src/lib/components/form-fields/button-field/button-field.component.ts
@@ -12,7 +12,7 @@ import { TranslateModule } from '@ngx-translate/core';
   selector: 'lab900-button-field',
   templateUrl: './button-field.component.html',
   standalone: true,
-  imports: [MatTooltip, MatLabel, ReactiveFormsModule, TranslateModule, Lab900ButtonComponent, MatFormField]
+  imports: [MatTooltip, MatLabel, ReactiveFormsModule, TranslateModule, Lab900ButtonComponent]
 })
 export class ButtonFieldComponent extends FormComponent<FormFieldButton> {
   @HostBinding('class')

--- a/lib/src/lib/components/form-fields/button-field/button-field.model.ts
+++ b/lib/src/lib/components/form-fields/button-field/button-field.model.ts
@@ -27,6 +27,7 @@ export interface FormFieldButtonOptions extends FormFieldBaseOptions {
   suffixIcon?: string;
   svgIcon?: boolean;
   containerClass?: string;
+  buttonId?: string;
 }
 
 export interface FormFieldButton<T extends string | number = string>

--- a/lib/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
+++ b/lib/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-button-toggle-field button-toggle-field mat-form-field-wrapper"
-    id="lab900-button-toggle-field-{{ fieldAttribute }}"
+    id="lab900-button-toggle-field-{{ elementId }}"
   >
     @if (label(); as label) {
       <div class="lab900-button-toggle-field__label">
@@ -18,6 +18,7 @@
           (change)="onChange($event)"
           [matTooltip]="value?.tooltip?.text | translate"
           [matTooltipPosition]="value?.tooltip?.position || 'above'"
+          id="mat-button-toggle-{{elementId}}"
         >
           @if (value?.icon?.position === 'left') {
             <lab900-icon [icon]="value.icon"></lab900-icon>

--- a/lib/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
+++ b/lib/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-button-toggle-field button-toggle-field mat-form-field-wrapper"
-    id="lab900-button-toggle-field-{{ this.elementId() }}"
+    id="lab900-button-toggle-field-{{ elementId() }}"
   >
     @if (label(); as label) {
       <div class="lab900-button-toggle-field__label">

--- a/lib/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
+++ b/lib/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-button-toggle-field button-toggle-field mat-form-field-wrapper"
-    id="lab900-button-toggle-field-{{ elementId }}"
+    id="lab900-button-toggle-field-{{ this.elementId() }}"
   >
     @if (label(); as label) {
       <div class="lab900-button-toggle-field__label">

--- a/lib/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.ts
+++ b/lib/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.ts
@@ -3,7 +3,6 @@ import { FormComponent } from '../../AbstractFormComponent';
 import { FormFieldButtonToggle } from './button-toggle-field.model';
 import { MatButtonToggle, MatButtonToggleChange, MatButtonToggleGroup } from '@angular/material/button-toggle';
 import { ReactiveFormsModule } from '@angular/forms';
-import { AsyncPipe } from '@angular/common';
 import { MatError, MatLabel } from '@angular/material/form-field';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -22,7 +21,6 @@ import { IconComponent } from '@lab900/ui';
     MatTooltip,
     IconComponent,
     MatError,
-    AsyncPipe,
   ],
 })
 export class ButtonToggleFieldComponent extends FormComponent<FormFieldButtonToggle> {

--- a/lib/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
+++ b/lib/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-checkbox-field" id="lab900-checkbox-field-{{ fieldAttribute }}">
+  <div [formGroup]="group" class="lab900-checkbox-field" id="lab900-checkbox-field-{{ elementId }}">
     <mat-checkbox
       #checkbox
       [color]="color()"

--- a/lib/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
+++ b/lib/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-checkbox-field" id="lab900-checkbox-field-{{ this.elementId() }}">
+  <div [formGroup]="group" class="lab900-checkbox-field" id="lab900-checkbox-field-{{ elementId() }}">
     <mat-checkbox
       #checkbox
       [color]="color()"

--- a/lib/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
+++ b/lib/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-checkbox-field" id="lab900-checkbox-field-{{ elementId }}">
+  <div [formGroup]="group" class="lab900-checkbox-field" id="lab900-checkbox-field-{{ this.elementId() }}">
     <mat-checkbox
       #checkbox
       [color]="color()"

--- a/lib/src/lib/components/form-fields/date-field/date-field.component.html
+++ b/lib/src/lib/components/form-fields/date-field/date-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ elementId }}">
+  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ this.elementId() }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/date-field/date-field.component.html
+++ b/lib/src/lib/components/form-fields/date-field/date-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ this.elementId() }}">
+  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ elementId() }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/date-field/date-field.component.html
+++ b/lib/src/lib/components/form-fields/date-field/date-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ fieldAttribute }}">
+  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ elementId }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/date-field/date-field.component.ts
+++ b/lib/src/lib/components/form-fields/date-field/date-field.component.ts
@@ -3,7 +3,6 @@ import { FormComponent } from '../../AbstractFormComponent';
 import { FormFieldDatePicker } from './date-field.model';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
-import { AsyncPipe } from '@angular/common';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatInputModule } from '@angular/material/input';
@@ -18,7 +17,6 @@ import { MatInputModule } from '@angular/material/input';
     ReactiveFormsModule,
     MatDatepickerModule,
     TranslateModule,
-    AsyncPipe,
     MatDatepickerModule,
   ],
 })

--- a/lib/src/lib/components/form-fields/date-range-field/date-range-field.component.html
+++ b/lib/src/lib/components/form-fields/date-range-field/date-range-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden && dateFormGroup) {
-  <mat-form-field [formGroup]="group" class="lab900-date-range-field" id="lab900-date-range-field-{{ elementId }}">
+  <mat-form-field [formGroup]="group" class="lab900-date-range-field" id="lab900-date-range-field-{{ elementId() }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/date-range-field/date-range-field.component.html
+++ b/lib/src/lib/components/form-fields/date-range-field/date-range-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden && dateFormGroup) {
-  <mat-form-field [formGroup]="group" class="lab900-date-range-field" id="lab900-date-range-field-{{ fieldAttribute }}">
+  <mat-form-field [formGroup]="group" class="lab900-date-range-field" id="lab900-date-range-field-{{ elementId }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/date-range-field/date-range-field.component.ts
+++ b/lib/src/lib/components/form-fields/date-range-field/date-range-field.component.ts
@@ -7,7 +7,6 @@ import {
   MatDateRangeInput,
 } from '@angular/material/datepicker';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { AsyncPipe } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatInputModule } from '@angular/material/input';
 
@@ -22,7 +21,6 @@ import { MatInputModule } from '@angular/material/input';
     ReactiveFormsModule,
     TranslateModule,
     MatDatepickerModule,
-    AsyncPipe,
   ],
 })
 export class DateRangeFieldComponent extends FormComponent<FormFieldDateRange> {

--- a/lib/src/lib/components/form-fields/date-time-field/date-time-field.component.html
+++ b/lib/src/lib/components/form-fields/date-time-field/date-time-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-date-time-field" id="lab900-date-time-field-{{ elementId }}">
+  <mat-form-field [formGroup]="group" class="lab900-date-time-field" id="lab900-date-time-field-{{ elementId() }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/date-time-field/date-time-field.component.html
+++ b/lib/src/lib/components/form-fields/date-time-field/date-time-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-date-time-field" id="lab900-date-time-field-{{ fieldAttribute }}">
+  <mat-form-field [formGroup]="group" class="lab900-date-time-field" id="lab900-date-time-field-{{ elementId }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/date-time-field/date-time-field.component.ts
+++ b/lib/src/lib/components/form-fields/date-time-field/date-time-field.component.ts
@@ -9,7 +9,6 @@ import {
 import { NgxMatSingleDateSelectionModel } from '@angular-material-components/datetime-picker/lib/date-selection-model';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
-import { AsyncPipe } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButton } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
@@ -25,7 +24,6 @@ import { MatInputModule } from '@angular/material/input';
     NgxMatDatetimePickerModule,
     TranslateModule,
     MatButton,
-    AsyncPipe,
   ],
 })
 export class DateTimeFieldComponent extends FormComponent<FormFieldDateTimePicker> {

--- a/lib/src/lib/components/form-fields/date-year-month-field/date-year-month-field.component.html
+++ b/lib/src/lib/components/form-fields/date-year-month-field/date-year-month-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ elementId }}">
+  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ this.elementId() }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/date-year-month-field/date-year-month-field.component.html
+++ b/lib/src/lib/components/form-fields/date-year-month-field/date-year-month-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ this.elementId() }}">
+  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ elementId() }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/date-year-month-field/date-year-month-field.component.html
+++ b/lib/src/lib/components/form-fields/date-year-month-field/date-year-month-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ fieldAttribute }}">
+  <mat-form-field [formGroup]="group" class="lab900-date-field" id="lab900-date-field-{{ elementId }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/date-year-month-field/date-year-month-field.component.ts
+++ b/lib/src/lib/components/form-fields/date-year-month-field/date-year-month-field.component.ts
@@ -11,7 +11,6 @@ import {
 import { MAT_DATE_FORMATS } from '@angular/material/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
-import { AsyncPipe } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatInputModule } from '@angular/material/input';
 
@@ -38,7 +37,6 @@ import { MatInputModule } from '@angular/material/input';
   imports: [
     ReactiveFormsModule,
     TranslateModule,
-    AsyncPipe,
     MatDatepickerModule,
     MatFormFieldModule,
     MatInputModule,

--- a/lib/src/lib/components/form-fields/drag-n-drop-file-field/drag-n-drop-file-field.component.html
+++ b/lib/src/lib/components/form-fields/drag-n-drop-file-field/drag-n-drop-file-field.component.html
@@ -2,7 +2,7 @@
   @if (schema.title) {
     <span class="lab900-form-field-label" translate>{{ schema.title }}</span>
   }
-  <div class="upload-file" [class.upload-file--compact]="options.compact" id="upload-file-{{elementId}}">
+  <div class="upload-file" [class.upload-file--compact]="options.compact" id="upload-file-{{this.elementId()}}">
     <div
       lab900DropFile
       class="upload-file__container"

--- a/lib/src/lib/components/form-fields/drag-n-drop-file-field/drag-n-drop-file-field.component.html
+++ b/lib/src/lib/components/form-fields/drag-n-drop-file-field/drag-n-drop-file-field.component.html
@@ -2,7 +2,7 @@
   @if (schema.title) {
     <span class="lab900-form-field-label" translate>{{ schema.title }}</span>
   }
-  <div class="upload-file" [class.upload-file--compact]="options.compact" id="upload-file-{{this.elementId()}}">
+  <div class="upload-file" [class.upload-file--compact]="options.compact" id="upload-file-{{ elementId() }}">
     <div
       lab900DropFile
       class="upload-file__container"

--- a/lib/src/lib/components/form-fields/drag-n-drop-file-field/drag-n-drop-file-field.component.html
+++ b/lib/src/lib/components/form-fields/drag-n-drop-file-field/drag-n-drop-file-field.component.html
@@ -2,7 +2,7 @@
   @if (schema.title) {
     <span class="lab900-form-field-label" translate>{{ schema.title }}</span>
   }
-  <div class="upload-file" [class.upload-file--compact]="options.compact">
+  <div class="upload-file" [class.upload-file--compact]="options.compact" id="upload-file-{{elementId}}">
     <div
       lab900DropFile
       class="upload-file__container"

--- a/lib/src/lib/components/form-fields/icon-field/icon-field.component.html
+++ b/lib/src/lib/components/form-fields/icon-field/icon-field.component.html
@@ -1,5 +1,5 @@
 @if (icon(); as icon) {
-  <div class="icon-field mat-form-field-wrapper" id="icon-field-{{elementId}}">
+  <div class="icon-field mat-form-field-wrapper" id="icon-field-{{this.elementId()}}">
     <lab900-icon [icon]="icon" />
   </div>
 }

--- a/lib/src/lib/components/form-fields/icon-field/icon-field.component.html
+++ b/lib/src/lib/components/form-fields/icon-field/icon-field.component.html
@@ -1,5 +1,5 @@
 @if (icon(); as icon) {
-  <div class="icon-field mat-form-field-wrapper" id="icon-field-{{this.elementId()}}">
+  <div class="icon-field mat-form-field-wrapper" id="icon-field-{{ elementId() }}">
     <lab900-icon [icon]="icon" />
   </div>
 }

--- a/lib/src/lib/components/form-fields/icon-field/icon-field.component.html
+++ b/lib/src/lib/components/form-fields/icon-field/icon-field.component.html
@@ -1,5 +1,5 @@
 @if (icon(); as icon) {
-  <div class="icon-field mat-form-field-wrapper">
+  <div class="icon-field mat-form-field-wrapper" id="icon-field-{{elementId}}">
     <lab900-icon [icon]="icon" />
   </div>
 }

--- a/lib/src/lib/components/form-fields/input-field/input-field.component.html
+++ b/lib/src/lib/components/form-fields/input-field/input-field.component.html
@@ -3,7 +3,7 @@
     [formGroup]="group"
     class="lab900-input-field {{ options?.align || 'left' }}"
     [class.spanFix]="options?.suffix || options?.prefix"
-    id="lab900-input-field-{{ elementId }}"
+    id="lab900-input-field-{{ this.elementId() }}"
   >
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/input-field/input-field.component.html
+++ b/lib/src/lib/components/form-fields/input-field/input-field.component.html
@@ -3,7 +3,7 @@
     [formGroup]="group"
     class="lab900-input-field {{ options?.align || 'left' }}"
     [class.spanFix]="options?.suffix || options?.prefix"
-    id="lab900-input-field-{{ fieldAttribute }}"
+    id="lab900-input-field-{{ elementId }}"
   >
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/input-field/input-field.component.html
+++ b/lib/src/lib/components/form-fields/input-field/input-field.component.html
@@ -3,7 +3,7 @@
     [formGroup]="group"
     class="lab900-input-field {{ options?.align || 'left' }}"
     [class.spanFix]="options?.suffix || options?.prefix"
-    id="lab900-input-field-{{ this.elementId() }}"
+    id="lab900-input-field-{{ elementId() }}"
   >
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.html
+++ b/lib/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-multi-lang-field lab900-multi-lang-field--{{ setting?.formField?.appearance || 'standard' }}"
-    id="lab900-multi-lang-field-{{ fieldAttribute }}"
+    id="lab900-multi-lang-field-{{ elementId }}"
     style="padding-bottom: 1.34375em"
   >
     <lab900-multi-lang-field-control

--- a/lib/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.html
+++ b/lib/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-multi-lang-field lab900-multi-lang-field--{{ setting?.formField?.appearance || 'standard' }}"
-    id="lab900-multi-lang-field-{{ this.elementId() }}"
+    id="lab900-multi-lang-field-{{ elementId() }}"
     style="padding-bottom: 1.34375em"
   >
     <lab900-multi-lang-field-control

--- a/lib/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.html
+++ b/lib/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-multi-lang-field lab900-multi-lang-field--{{ setting?.formField?.appearance || 'standard' }}"
-    id="lab900-multi-lang-field-{{ elementId }}"
+    id="lab900-multi-lang-field-{{ this.elementId() }}"
     style="padding-bottom: 1.34375em"
   >
     <lab900-multi-lang-field-control

--- a/lib/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.ts
+++ b/lib/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.ts
@@ -3,7 +3,6 @@ import { FormComponent } from '../../AbstractFormComponent';
 import { FormFieldMultiLang } from './multi-lang-input-field.model';
 import { MultiLangFieldControlComponent } from './multi-lang-field-control/multi-lang-field-control.component';
 import { MatError } from '@angular/material/form-field';
-import { AsyncPipe } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 
 @Component({
@@ -13,7 +12,6 @@ import { ReactiveFormsModule } from '@angular/forms';
   imports: [
     MultiLangFieldControlComponent,
     MatError,
-    AsyncPipe,
     ReactiveFormsModule,
   ],
 })

--- a/lib/src/lib/components/form-fields/password-field/password-field.component.html
+++ b/lib/src/lib/components/form-fields/password-field/password-field.component.html
@@ -2,7 +2,7 @@
   <mat-form-field
     [formGroup]="group"
     class="lab900-input-field {{ options?.align || 'left' }}"
-    id="lab900-input-field-{{ elementId }}"
+    id="lab900-input-field-{{ this.elementId() }}"
   >
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/password-field/password-field.component.html
+++ b/lib/src/lib/components/form-fields/password-field/password-field.component.html
@@ -2,7 +2,7 @@
   <mat-form-field
     [formGroup]="group"
     class="lab900-input-field {{ options?.align || 'left' }}"
-    id="lab900-input-field-{{ fieldAttribute }}"
+    id="lab900-input-field-{{ elementId }}"
   >
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/password-field/password-field.component.html
+++ b/lib/src/lib/components/form-fields/password-field/password-field.component.html
@@ -2,7 +2,7 @@
   <mat-form-field
     [formGroup]="group"
     class="lab900-input-field {{ options?.align || 'left' }}"
-    id="lab900-input-field-{{ this.elementId() }}"
+    id="lab900-input-field-{{ elementId() }}"
   >
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/password-field/password-field.component.ts
+++ b/lib/src/lib/components/form-fields/password-field/password-field.component.ts
@@ -2,7 +2,7 @@ import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../AbstractFormComponent';
 import { FormFieldPassword } from './password-field.model';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { AsyncPipe, NgClass } from '@angular/common';
+import { NgClass } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { TranslateModule } from '@ngx-translate/core';
@@ -22,7 +22,6 @@ import { IconComponent } from '@lab900/ui';
     NgClass,
     AutofocusDirective,
     IconComponent,
-    AsyncPipe,
   ],
 })
 export class PasswordFieldComponent extends FormComponent<FormFieldPassword> {

--- a/lib/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
+++ b/lib/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-radio-buttons-field" id="lab900-radio-buttons-field-{{ fieldAttribute }}">
+  <div [formGroup]="group" class="lab900-radio-buttons-field" id="lab900-radio-buttons-field-{{ elementId }}">
     @if (label(); as label) {
       <div class="lab900-radio-buttons-field__label">
         <mat-label>{{ label | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
+++ b/lib/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-radio-buttons-field" id="lab900-radio-buttons-field-{{ this.elementId() }}">
+  <div [formGroup]="group" class="lab900-radio-buttons-field" id="lab900-radio-buttons-field-{{ elementId() }}">
     @if (label(); as label) {
       <div class="lab900-radio-buttons-field__label">
         <mat-label>{{ label | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
+++ b/lib/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-radio-buttons-field" id="lab900-radio-buttons-field-{{ elementId }}">
+  <div [formGroup]="group" class="lab900-radio-buttons-field" id="lab900-radio-buttons-field-{{ this.elementId() }}">
     @if (label(); as label) {
       <div class="lab900-radio-buttons-field__label">
         <mat-label>{{ label | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/range-slider-field/range-slider-field.component.html
+++ b/lib/src/lib/components/form-fields/range-slider-field/range-slider-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-range-slider-field" id="lab900-range-slider-field-{{ fieldAttribute }}">
+  <div [formGroup]="group" class="lab900-range-slider-field" id="lab900-range-slider-field-{{ elementId }}">
     @if (label()) {
       <span class="lab900-form-field-label">{{ label() | translate }}</span>
     }

--- a/lib/src/lib/components/form-fields/range-slider-field/range-slider-field.component.html
+++ b/lib/src/lib/components/form-fields/range-slider-field/range-slider-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-range-slider-field" id="lab900-range-slider-field-{{ elementId }}">
+  <div [formGroup]="group" class="lab900-range-slider-field" id="lab900-range-slider-field-{{ this.elementId() }}">
     @if (label()) {
       <span class="lab900-form-field-label">{{ label() | translate }}</span>
     }

--- a/lib/src/lib/components/form-fields/range-slider-field/range-slider-field.component.html
+++ b/lib/src/lib/components/form-fields/range-slider-field/range-slider-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-range-slider-field" id="lab900-range-slider-field-{{ this.elementId() }}">
+  <div [formGroup]="group" class="lab900-range-slider-field" id="lab900-range-slider-field-{{ elementId() }}">
     @if (label()) {
       <span class="lab900-form-field-label">{{ label() | translate }}</span>
     }

--- a/lib/src/lib/components/form-fields/readonly-field/readonly-field.component.html
+++ b/lib/src/lib/components/form-fields/readonly-field/readonly-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div class="lab900-readonly-field" [class]="getReadonlyContainerClass()" id="lab900-readonly-field-{{this.elementId()}}">
+  <div class="lab900-readonly-field" [class]="getReadonlyContainerClass()" id="lab900-readonly-field-{{ elementId() }}">
     @if (readonlyLabel(); as label) {
       <span class="lab900-readonly-field__label">{{ label | translate }}</span>
     }

--- a/lib/src/lib/components/form-fields/readonly-field/readonly-field.component.html
+++ b/lib/src/lib/components/form-fields/readonly-field/readonly-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div class="lab900-readonly-field" [class]="getReadonlyContainerClass()">
+  <div class="lab900-readonly-field" [class]="getReadonlyContainerClass()" id="lab900-readonly-field-{{elementId}}">
     @if (readonlyLabel(); as label) {
       <span class="lab900-readonly-field__label">{{ label | translate }}</span>
     }

--- a/lib/src/lib/components/form-fields/readonly-field/readonly-field.component.html
+++ b/lib/src/lib/components/form-fields/readonly-field/readonly-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div class="lab900-readonly-field" [class]="getReadonlyContainerClass()" id="lab900-readonly-field-{{elementId}}">
+  <div class="lab900-readonly-field" [class]="getReadonlyContainerClass()" id="lab900-readonly-field-{{this.elementId()}}">
     @if (readonlyLabel(); as label) {
       <span class="lab900-readonly-field__label">{{ label | translate }}</span>
     }

--- a/lib/src/lib/components/form-fields/repeater-field/repeater-field.component.html
+++ b/lib/src/lib/components/form-fields/repeater-field/repeater-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-repeater-field repeater-field"
-    id="lab900-repeater-field-{{ this.elementId() }}"
+    id="lab900-repeater-field-{{ elementId() }}"
     [class.fixed-list]="fixedList"
   >
     <div [formArrayName]="fieldAttribute">

--- a/lib/src/lib/components/form-fields/repeater-field/repeater-field.component.html
+++ b/lib/src/lib/components/form-fields/repeater-field/repeater-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-repeater-field repeater-field"
-    id="lab900-repeater-field-{{ fieldAttribute }}"
+    id="lab900-repeater-field-{{ elementId }}"
     [class.fixed-list]="fixedList"
   >
     <div [formArrayName]="fieldAttribute">

--- a/lib/src/lib/components/form-fields/repeater-field/repeater-field.component.html
+++ b/lib/src/lib/components/form-fields/repeater-field/repeater-field.component.html
@@ -2,7 +2,7 @@
   <div
     [formGroup]="group"
     class="lab900-repeater-field repeater-field"
-    id="lab900-repeater-field-{{ elementId }}"
+    id="lab900-repeater-field-{{ this.elementId() }}"
     [class.fixed-list]="fixedList"
   >
     <div [formArrayName]="fieldAttribute">

--- a/lib/src/lib/components/form-fields/repeater-field/repeater-field.component.ts
+++ b/lib/src/lib/components/form-fields/repeater-field/repeater-field.component.ts
@@ -4,7 +4,6 @@ import { ReactiveFormsModule, UntypedFormArray } from '@angular/forms';
 import { Lab900FormBuilderService } from '../../../services/form-builder.service';
 import { MatError, matFormFieldAnimations } from '@angular/material/form-field';
 import { FormFieldRepeater } from './repeater-field.model';
-import { AsyncPipe } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -27,7 +26,6 @@ export const DEFAULT_REPEATER_MIN_ROWS = 1;
     FormFieldDirective,
     MatMiniFabButton,
     MatError,
-    AsyncPipe,
     MatButton,
   ],
 })

--- a/lib/src/lib/components/form-fields/search-field/search-field.component.html
+++ b/lib/src/lib/components/form-fields/search-field/search-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-input-field" id="lab900-input-field-{{ elementId }}">
+  <mat-form-field [formGroup]="group" class="lab900-input-field" id="lab900-input-field-{{ this.elementId() }}">
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/search-field/search-field.component.html
+++ b/lib/src/lib/components/form-fields/search-field/search-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-input-field" id="lab900-input-field-{{ this.elementId() }}">
+  <mat-form-field [formGroup]="group" class="lab900-input-field" id="lab900-input-field-{{ elementId() }}">
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/search-field/search-field.component.html
+++ b/lib/src/lib/components/form-fields/search-field/search-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-input-field" id="lab900-input-field-{{ fieldAttribute }}">
+  <mat-form-field [formGroup]="group" class="lab900-input-field" id="lab900-input-field-{{ elementId }}">
     @if (label()) {
       <mat-label>{{ label() | translate }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.html
@@ -3,7 +3,7 @@
     [formGroup]="group"
     class="lab900-select-field"
     [class.has-value]="hasValue()"
-    id="lab900-select-field-{{ elementId }}"
+    id="lab900-select-field-{{ this.elementId() }}"
   >
     @if (label(); as label) {
       <mat-label>

--- a/lib/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.html
@@ -3,7 +3,7 @@
     [formGroup]="group"
     class="lab900-select-field"
     [class.has-value]="hasValue()"
-    id="lab900-select-field-{{ fieldAttribute }}"
+    id="lab900-select-field-{{ elementId }}"
   >
     @if (label(); as label) {
       <mat-label>

--- a/lib/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/lib/src/lib/components/form-fields/select-field/select-field.component.html
@@ -3,7 +3,7 @@
     [formGroup]="group"
     class="lab900-select-field"
     [class.has-value]="hasValue()"
-    id="lab900-select-field-{{ this.elementId() }}"
+    id="lab900-select-field-{{ elementId() }}"
   >
     @if (label(); as label) {
       <mat-label>

--- a/lib/src/lib/components/form-fields/slide-toggle-field/slide-toggle-field.component.html
+++ b/lib/src/lib/components/form-fields/slide-toggle-field/slide-toggle-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-slide-toggle-field mat-form-field-wrapper" id="lab900-slide-toggle-field-{{ fieldAttribute }}">
+  <div [formGroup]="group" class="lab900-slide-toggle-field mat-form-field-wrapper" id="lab900-slide-toggle-field-{{ elementId }}">
     @if (schema.title) {
       <div class="lab900-slide-toggle-field__title">
         <mat-label>{{ schema.title | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/slide-toggle-field/slide-toggle-field.component.html
+++ b/lib/src/lib/components/form-fields/slide-toggle-field/slide-toggle-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-slide-toggle-field mat-form-field-wrapper" id="lab900-slide-toggle-field-{{ this.elementId() }}">
+  <div [formGroup]="group" class="lab900-slide-toggle-field mat-form-field-wrapper" id="lab900-slide-toggle-field-{{ elementId() }}">
     @if (schema.title) {
       <div class="lab900-slide-toggle-field__title">
         <mat-label>{{ schema.title | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/slide-toggle-field/slide-toggle-field.component.html
+++ b/lib/src/lib/components/form-fields/slide-toggle-field/slide-toggle-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <div [formGroup]="group" class="lab900-slide-toggle-field mat-form-field-wrapper" id="lab900-slide-toggle-field-{{ elementId }}">
+  <div [formGroup]="group" class="lab900-slide-toggle-field mat-form-field-wrapper" id="lab900-slide-toggle-field-{{ this.elementId() }}">
     @if (schema.title) {
       <div class="lab900-slide-toggle-field__title">
         <mat-label>{{ schema.title | translate }}</mat-label>

--- a/lib/src/lib/components/form-fields/slide-toggle-field/slide-toggle-field.component.ts
+++ b/lib/src/lib/components/form-fields/slide-toggle-field/slide-toggle-field.component.ts
@@ -2,7 +2,6 @@ import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../AbstractFormComponent';
 import { FormFieldSlideToggle } from './slide-toggle-field.model';
 import { ReactiveFormsModule } from '@angular/forms';
-import { AsyncPipe } from '@angular/common';
 import { MatError, MatLabel } from '@angular/material/form-field';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { TranslateModule } from '@ngx-translate/core';
@@ -26,7 +25,6 @@ import { TranslateModule } from '@ngx-translate/core';
     MatSlideToggle,
     TranslateModule,
     MatError,
-    AsyncPipe,
   ],
 })
 export class SlideToggleFieldComponent extends FormComponent<FormFieldSlideToggle> {

--- a/lib/src/lib/components/form-fields/textarea-field/textarea-field.component.html
+++ b/lib/src/lib/components/form-fields/textarea-field/textarea-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-textarea-field" id="lab900-textarea-field-{{ elementId }}">
+  <mat-form-field [formGroup]="group" class="lab900-textarea-field" id="lab900-textarea-field-{{ this.elementId() }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/textarea-field/textarea-field.component.html
+++ b/lib/src/lib/components/form-fields/textarea-field/textarea-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-textarea-field" id="lab900-textarea-field-{{ fieldAttribute }}">
+  <mat-form-field [formGroup]="group" class="lab900-textarea-field" id="lab900-textarea-field-{{ elementId }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/textarea-field/textarea-field.component.html
+++ b/lib/src/lib/components/form-fields/textarea-field/textarea-field.component.html
@@ -1,5 +1,5 @@
 @if (!fieldIsHidden) {
-  <mat-form-field [formGroup]="group" class="lab900-textarea-field" id="lab900-textarea-field-{{ this.elementId() }}">
+  <mat-form-field [formGroup]="group" class="lab900-textarea-field" id="lab900-textarea-field-{{ elementId() }}">
     @if (schema.title) {
       <mat-label translate>{{ schema.title }}</mat-label>
     }

--- a/lib/src/lib/components/form-fields/textarea-field/textarea-field.component.ts
+++ b/lib/src/lib/components/form-fields/textarea-field/textarea-field.component.ts
@@ -2,7 +2,6 @@ import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../AbstractFormComponent';
 import { FormFieldTextarea } from './textarea-field.model';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { AsyncPipe } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { TranslateModule } from '@ngx-translate/core';
@@ -17,7 +16,6 @@ import { TranslateModule } from '@ngx-translate/core';
     MatInputModule,
     ReactiveFormsModule,
     TranslateModule,
-    AsyncPipe,
   ],
 })
 export class TextareaFieldComponent extends FormComponent<FormFieldTextarea> {

--- a/lib/src/lib/components/form-row/form-row.component.html
+++ b/lib/src/lib/components/form-row/form-row.component.html
@@ -1,16 +1,17 @@
 @if (visible() && _schema()) {
-  <div [hidden]="isHidden(schema)" class="lab900-form-row {{ _options()?.customClass }}">
+  <div [hidden]="isHidden(schema)" class="lab900-form-row {{ _options()?.customClass }}" id="lab900-form-row-{{elementId}}">
     @if ((fieldIsReadonly && _options()?.readonlyLabel) || label()) {
       <span class="lab900-form-field-label lab900-form-row-label {{ _options()?.customTitleClass }}">{{
         (!fieldIsReadonly ? label() : _options()?.readonlyLabel || label()) | translate
       }}</span>
     }
-    <div class="form-row" [class.mobile-cols]="_options()?.mobileCols">
+    <div class="form-row" [class.mobile-cols]="_options()?.mobileCols" id="form-col-{{elementId}}">
       @for (field of nestedFields(); track field) {
         <div
           class="form-col"
           [class.hidden]="isHidden(field)"
           [style.width]="(100 * (field.options?.colspan || 12)) / 12 + '%'"
+          id="form-col-{{elementId}}-{{field.options?.customId}}"
         >
           <ng-container
             lab900FormField

--- a/lib/src/lib/components/form-row/form-row.component.html
+++ b/lib/src/lib/components/form-row/form-row.component.html
@@ -1,17 +1,17 @@
 @if (visible() && _schema()) {
-  <div [hidden]="isHidden(schema)" class="lab900-form-row {{ _options()?.customClass }}" id="lab900-form-row-{{ this.elementId() }}">
+  <div [hidden]="isHidden(schema)" class="lab900-form-row {{ _options()?.customClass }}" id="lab900-form-row-{{ elementId() }}">
     @if ((fieldIsReadonly && _options()?.readonlyLabel) || label()) {
       <span class="lab900-form-field-label lab900-form-row-label {{ _options()?.customTitleClass }}">{{
         (!fieldIsReadonly ? label() : _options()?.readonlyLabel || label()) | translate
       }}</span>
     }
-    <div class="form-row" [class.mobile-cols]="_options()?.mobileCols" id="form-col-{{ this.elementId() }}">
+    <div class="form-row" [class.mobile-cols]="_options()?.mobileCols" id="form-col-{{ elementId() }}">
       @for (field of nestedFields(); track field) {
         <div
           class="form-col"
           [class.hidden]="isHidden(field)"
           [style.width]="(100 * (_options()?.colspan || 12)) / 12 + '%'"
-          id="form-col-{{this.elementId()}}-{{_options()?.elementId}}"
+          id="form-col-{{ elementId() }}-{{ _options()?.elementId }}"
         >
           <ng-container
             lab900FormField

--- a/lib/src/lib/components/form-row/form-row.component.html
+++ b/lib/src/lib/components/form-row/form-row.component.html
@@ -1,17 +1,17 @@
 @if (visible() && _schema()) {
-  <div [hidden]="isHidden(schema)" class="lab900-form-row {{ _options()?.customClass }}" id="lab900-form-row-{{elementId}}">
+  <div [hidden]="isHidden(schema)" class="lab900-form-row {{ _options()?.customClass }}" id="lab900-form-row-{{ this.elementId() }}">
     @if ((fieldIsReadonly && _options()?.readonlyLabel) || label()) {
       <span class="lab900-form-field-label lab900-form-row-label {{ _options()?.customTitleClass }}">{{
         (!fieldIsReadonly ? label() : _options()?.readonlyLabel || label()) | translate
       }}</span>
     }
-    <div class="form-row" [class.mobile-cols]="_options()?.mobileCols" id="form-col-{{elementId}}">
+    <div class="form-row" [class.mobile-cols]="_options()?.mobileCols" id="form-col-{{ this.elementId() }}">
       @for (field of nestedFields(); track field) {
         <div
           class="form-col"
           [class.hidden]="isHidden(field)"
-          [style.width]="(100 * (field.options?.colspan || 12)) / 12 + '%'"
-          id="form-col-{{elementId}}-{{field.options?.customId}}"
+          [style.width]="(100 * (_options()?.colspan || 12)) / 12 + '%'"
+          id="form-col-{{this.elementId()}}-{{_options()?.customId}}"
         >
           <ng-container
             lab900FormField

--- a/lib/src/lib/components/form-row/form-row.component.html
+++ b/lib/src/lib/components/form-row/form-row.component.html
@@ -11,7 +11,7 @@
           class="form-col"
           [class.hidden]="isHidden(field)"
           [style.width]="(100 * (_options()?.colspan || 12)) / 12 + '%'"
-          id="form-col-{{this.elementId()}}-{{_options()?.customId}}"
+          id="form-col-{{this.elementId()}}-{{_options()?.elementId}}"
         >
           <ng-container
             lab900FormField

--- a/lib/src/lib/models/Lab900FormConfig.ts
+++ b/lib/src/lib/models/Lab900FormConfig.ts
@@ -8,4 +8,5 @@ export interface Lab900FormConfig<
   title?: string;
   fields: Lab900FormField<R, T, DATE>[];
   readonly?: boolean;
+  customId?: string;
 }

--- a/lib/src/lib/models/Lab900FormConfig.ts
+++ b/lib/src/lib/models/Lab900FormConfig.ts
@@ -8,5 +8,5 @@ export interface Lab900FormConfig<
   title?: string;
   fields: Lab900FormField<R, T, DATE>[];
   readonly?: boolean;
-  customId?: string;
+  formId?: string;
 }

--- a/lib/src/lib/models/form-field-base.ts
+++ b/lib/src/lib/models/form-field-base.ts
@@ -52,5 +52,5 @@ export interface FormFieldBaseOptions {
   infoTooltip?:
     | { text: string; icon?: string; class?: string }
     | ((data?: any) => { text: string; icon?: string; class?: string } | null);
-  customId?: string;
+  elementId?: string; // Overrides the attribute name for the element ID if set; otherwise, defaults to the attribute name.
 }

--- a/lib/src/lib/models/form-field-base.ts
+++ b/lib/src/lib/models/form-field-base.ts
@@ -52,4 +52,5 @@ export interface FormFieldBaseOptions {
   infoTooltip?:
     | { text: string; icon?: string; class?: string }
     | ((data?: any) => { text: string; icon?: string; class?: string } | null);
+  customId?: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser-dynamic": "^18.1.1",
         "@angular/router": "^18.1.1",
         "@kolkov/angular-editor": "^3.0.0-beta.0 ",
-        "@lab900/ui": "^18.0.0",
+        "@lab900/ui": "^18.1.4",
         "@ngx-translate/core": "^15.0.0",
         "ngx-markdown": "^18.0.0",
         "ngx-mask": "^18.0.0",
@@ -5514,16 +5514,16 @@
       }
     },
     "node_modules/@lab900/ui": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lab900/ui/-/ui-18.0.0.tgz",
-      "integrity": "sha512-uU/RXI4CiUgPuEyTF/8wPhNM6xn/wyYwv0PMzSrOGcyUyuQ5Srug5XHUt0NOFyxM+g1HMWlU4AuSkA2Y/mujUQ==",
+      "version": "18.1.4",
+      "resolved": "https://registry.npmjs.org/@lab900/ui/-/ui-18.1.4.tgz",
+      "integrity": "sha512-dimLvTuBcjX6uvUPsVrST3KjB5C9p+b2TldULUKM8mYXBlKhV2atydUuLN/NiWbJWloNnr1Bkgd/n+5vYzRAvQ==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "@angular/common": ">=18.0.0",
-        "@angular/core": ">=18.0.0",
-        "@angular/material": ">=18.0.0",
+        "@angular/common": ">=18.1.0",
+        "@angular/core": ">=18.1.0",
+        "@angular/material": ">=18.1.0",
         "@ngx-translate/core": ">=15.0.0"
       }
     },
@@ -31248,9 +31248,9 @@
       }
     },
     "@lab900/ui": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lab900/ui/-/ui-18.0.0.tgz",
-      "integrity": "sha512-uU/RXI4CiUgPuEyTF/8wPhNM6xn/wyYwv0PMzSrOGcyUyuQ5Srug5XHUt0NOFyxM+g1HMWlU4AuSkA2Y/mujUQ==",
+      "version": "18.1.4",
+      "resolved": "https://registry.npmjs.org/@lab900/ui/-/ui-18.1.4.tgz",
+      "integrity": "sha512-dimLvTuBcjX6uvUPsVrST3KjB5C9p+b2TldULUKM8mYXBlKhV2atydUuLN/NiWbJWloNnr1Bkgd/n+5vYzRAvQ==",
       "requires": {
         "tslib": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@angular/platform-browser-dynamic": "^18.1.1",
     "@angular/router": "^18.1.1",
     "@kolkov/angular-editor": "^3.0.0-beta.0 ",
-    "@lab900/ui": "^18.0.0",
+    "@lab900/ui": "^18.1.4",
     "@ngx-translate/core": "^15.0.0",
     "ngx-markdown": "^18.0.0",
     "ngx-mask": "^18.0.0",

--- a/src/app/modules/showcase-forms/examples/form-conditionals-example/form-conditionals-example.component.config.ts
+++ b/src/app/modules/showcase-forms/examples/form-conditionals-example/form-conditionals-example.component.config.ts
@@ -6,13 +6,14 @@ export const formConditionalsData = {
 };
 
 export const formConditionalsExample: Lab900FormConfig = {
+  formId: 'exampleFormId',
   fields: [
     {
       attribute: 'role',
       editType: EditType.Select,
       title: 'Role',
       options: {
-        customId: 'customId-Role',
+        customId: 'customIdRole',
         colspan: 6,
         selectOptions: [
           { label: '', value: null },

--- a/src/app/modules/showcase-forms/examples/form-conditionals-example/form-conditionals-example.component.config.ts
+++ b/src/app/modules/showcase-forms/examples/form-conditionals-example/form-conditionals-example.component.config.ts
@@ -1,5 +1,4 @@
 import { EditType, Lab900FormConfig } from '@lab900/forms';
-import { ValueLabel } from '@lab900/forms';
 
 export const formConditionalsData = {
   country: 'BEL',
@@ -13,7 +12,7 @@ export const formConditionalsExample: Lab900FormConfig = {
       editType: EditType.Select,
       title: 'Role',
       options: {
-        customId: 'customIdRole',
+        elementId: 'customIdRole',
         colspan: 6,
         selectOptions: [
           { label: '', value: null },
@@ -26,7 +25,7 @@ export const formConditionalsExample: Lab900FormConfig = {
       attribute: '',
       editType: EditType.Row,
       options: {
-        customId: 'rowCustomId',
+        elementId: 'rowCustomId',
       },
       nestedFields: [
         {
@@ -34,7 +33,7 @@ export const formConditionalsExample: Lab900FormConfig = {
           editType: EditType.Select,
           title: 'Country',
           options: {
-            customId: 'countryCustomId',
+            elementId: 'countryCustomId',
             colspan: 6,
           },
           conditions: [
@@ -62,10 +61,7 @@ export const formConditionalsExample: Lab900FormConfig = {
           conditions: [
             {
               dependOn: ['country', 'role'],
-              conditionalOptions: (value: {
-                country: string;
-                role: string;
-              }) => {
+              conditionalOptions: (value: { country: string; role: string }) => {
                 switch (value?.country) {
                   case 'BEL':
                     return [

--- a/src/app/modules/showcase-forms/examples/form-conditionals-example/form-conditionals-example.component.config.ts
+++ b/src/app/modules/showcase-forms/examples/form-conditionals-example/form-conditionals-example.component.config.ts
@@ -12,6 +12,7 @@ export const formConditionalsExample: Lab900FormConfig = {
       editType: EditType.Select,
       title: 'Role',
       options: {
+        customId: 'customId-Role',
         colspan: 6,
         selectOptions: [
           { label: '', value: null },
@@ -23,12 +24,16 @@ export const formConditionalsExample: Lab900FormConfig = {
     {
       attribute: '',
       editType: EditType.Row,
+      options: {
+        customId: 'rowCustomId',
+      },
       nestedFields: [
         {
           attribute: 'country',
           editType: EditType.Select,
           title: 'Country',
           options: {
+            customId: 'countryCustomId',
             colspan: 6,
           },
           conditions: [

--- a/src/app/modules/showcase-forms/examples/form-condtional-validation-example/form-conditional-validation-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-condtional-validation-example/form-conditional-validation-example.component.ts
@@ -16,7 +16,7 @@ export class FormConditionalValidationExampleComponent {
         editType: EditType.Checkbox,
         title: 'Mark as required',
         options: {
-          customId: 'markAsRequiredCustomId',
+          elementId: 'markAsRequiredCustomId',
           colspan: 6,
           disabledIndeterminate: true,
         },

--- a/src/app/modules/showcase-forms/examples/form-condtional-validation-example/form-conditional-validation-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-condtional-validation-example/form-conditional-validation-example.component.ts
@@ -16,6 +16,7 @@ export class FormConditionalValidationExampleComponent {
         editType: EditType.Checkbox,
         title: 'Mark as required',
         options: {
+          customId: 'markAsRequiredCustomId',
           colspan: 6,
           disabledIndeterminate: true,
         },

--- a/src/app/modules/showcase-forms/examples/form-field-button-toggle-example/form-field-button-toggle-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-button-toggle-example/form-field-button-toggle-example.component.ts
@@ -44,6 +44,7 @@ export class FormFieldButtonToggleExampleComponent {
             editType: EditType.ButtonToggle,
             options: {
               required: true,
+              customId: 'buttonGroupAttribute2-customId',
               buttonOptions: [
                 {
                   value: 'edit',

--- a/src/app/modules/showcase-forms/examples/form-field-button-toggle-example/form-field-button-toggle-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-button-toggle-example/form-field-button-toggle-example.component.ts
@@ -44,7 +44,7 @@ export class FormFieldButtonToggleExampleComponent {
             editType: EditType.ButtonToggle,
             options: {
               required: true,
-              customId: 'buttonGroupAttribute2-customId',
+              elementId: 'buttonGroupAttribute2-customId',
               buttonOptions: [
                 {
                   value: 'edit',

--- a/src/app/modules/showcase-forms/examples/form-field-inputs-example/form-field-inputs-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-inputs-example/form-field-inputs-example.component.ts
@@ -26,6 +26,7 @@ export class FormFieldInputsExampleComponent {
               readonly: true,
               readonlyContainerClass: 'readonlyInputCustomContainerClass',
               defaultValue: 'MANUAL',
+              customId: 'ExampleOfCustomId',
             },
           },
         ],

--- a/src/app/modules/showcase-forms/examples/form-field-inputs-example/form-field-inputs-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-inputs-example/form-field-inputs-example.component.ts
@@ -26,7 +26,7 @@ export class FormFieldInputsExampleComponent {
               readonly: true,
               readonlyContainerClass: 'readonlyInputCustomContainerClass',
               defaultValue: 'MANUAL',
-              customId: 'ExampleOfCustomId',
+              elementId: 'ExampleOfCustomId',
             },
           },
         ],


### PR DESCRIPTION
Added support for assigning custom IDs to form elements, including columns, rows, fields, and buttons. Previously, IDs were derived from the attributes provided. Now, there is the ability to override these IDs with other values.

While creating tests, I identified several scenarios where specifying a custom ID was useful. This feature resolves issues where attributes could not be added, where existing attributes were duplicated, or where no suitable ID was available.