### PR TITLE
fix/translate-title-of-textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 19.0.4
+
+- Bug fix: title of text area field is now properly translated
+
 ## 19.0.3
 
 - Bug fix: conditional fields throwing errors

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "19.0.3",
+  "version": "19.0.4",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "license": "MIT",
   "peerDependencies": {

--- a/lib/src/lib/components/form-fields/textarea-field/textarea-field.component.html
+++ b/lib/src/lib/components/form-fields/textarea-field/textarea-field.component.html
@@ -1,7 +1,7 @@
 @if (!fieldIsHidden) {
   <mat-form-field [formGroup]="group" class="lab900-textarea-field" id="lab900-textarea-field-{{ elementId() }}">
     @if (schema.title) {
-      <mat-label translate>{{ schema.title }}</mat-label>
+      <mat-label>{{ schema.title | translate }}</mat-label>
     }
     <textarea
       #input


### PR DESCRIPTION
**before:**
![image](https://github.com/user-attachments/assets/001758ac-dbed-4424-8233-3e4819d9b839)

**after:**
![image](https://github.com/user-attachments/assets/9f5ebc4f-a20c-488c-a1ea-c2257b61f820)
