### PR TITLE
Feat/update icon add translation to text option 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 19.1.13
+- Added translate logic to Icon field text option
+
 ## 19.1.11
 - Added text functionality to icon
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "19.1.11",
+  "version": "19.1.12",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "license": "MIT",
   "peerDependencies": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "19.1.12",
+  "version": "19.1.13",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "license": "MIT",
   "peerDependencies": {

--- a/lib/src/lib/components/form-fields/icon-field/icon-field.component.html
+++ b/lib/src/lib/components/form-fields/icon-field/icon-field.component.html
@@ -3,7 +3,7 @@
     <div class="icon-field mat-form-field-wrapper" id="icon-field-{{ elementId() }}">
       <lab900-icon [icon]="icon" />
       @if (text()) {
-        <span class="icon-text">{{ text() }}</span>
+        <span class="icon-text">{{ text() | translate }}</span>
       }
     </div>
   }

--- a/lib/src/lib/components/form-fields/icon-field/icon-field.component.ts
+++ b/lib/src/lib/components/form-fields/icon-field/icon-field.component.ts
@@ -3,6 +3,7 @@ import { FormComponent } from '../../AbstractFormComponent';
 import { FormFieldIcon } from './icon-field.model';
 import { IconComponent } from '@lab900/ui';
 import { Icon, ReactiveOption } from '../../../models/form-field-base';
+import { TranslatePipe } from '@ngx-translate/core';
 
 function computeReactiveIconOption(option: ReactiveOption<Icon>, groupValue: Signal<any>): Icon | undefined {
   let response: Icon | undefined = undefined;
@@ -22,7 +23,7 @@ function computeReactiveIconOption(option: ReactiveOption<Icon>, groupValue: Sig
   selector: 'lab900-icon-field',
   templateUrl: './icon-field.component.html',
   styleUrls: ['./icon-field.component.scss'],
-  imports: [IconComponent],
+  imports: [IconComponent, TranslatePipe],
   host: { class: 'lab900-form-field' },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
for: https://sea-tank.atlassian.net/browse/CAB-640
added the posibility to add text next to an icon
part 2 added translation logic.

screenshot:
![Screenshot 2025-04-22 at 17 02 26](https://github.com/user-attachments/assets/529fb2f4-100a-491e-bd4c-1ee86c3484fd)
